### PR TITLE
Meta

### DIFF
--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import subprocess
 import re
 import glob
+from datetime import datetime
 
 from watchdog.observers import Observer
 from watchdog.events import LoggingEventHandler, FileCreatedEvent, FileSystemEventHandler
@@ -54,13 +55,15 @@ def upload(src_path, bucket, base_key, s3_endpoint_url):
     base_key = os.path.join(base_key, '')
     src_path = os.path.join(src_path, '')
 
-    # Extract run number
-    match = re.search(r'.+_(.+_.+)_.+', basename(os.path.dirname(src_path)))
+    # Extract metadata
+    match = re.search(r'.+_((.+)_(.+))_.+', basename(os.path.dirname(src_path)))
 
     if not match:
         raise Exception(f'Could not extract run number from {src_path}')
 
     run_id = match.group(1)
+    instrument_id = match.group(2)
+    run_number = match.group(3)
 
     # Upload each directory that contains fastq files
     for dirname in glob.glob(src_path + '*/'):
@@ -72,7 +75,13 @@ def upload(src_path, bucket, base_key, s3_endpoint_url):
         project_code = basename(os.path.dirname(dirname))
         key = f'{base_key}{project_code}/{run_id}'
 
-        # Upload      
+        # Upload
+        utils.upload_json(bucket, f"{key}/meta.json", s3_endpoint_url, {
+            "project_code": project_code,
+            "instrument_id": instrument_id,
+            "run_number": run_number,
+            "upload_time": str(datetime.now())
+        })
         utils.s3_sync(dirname, bucket, key, s3_endpoint_url)
         
 

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -129,6 +129,8 @@ class TestBclManager(unittest.TestCase):
         bcl_manager.utils.s3_sync = s3_sync_mock
         bcl_manager.subprocess.run = Mock()
 
+        bcl_manager.glob.glob = Mock(return_value=["directory_name"])
+
         # Successful upload
         bcl_manager.upload(good_src_path, '', '', '')
 

--- a/utils.py
+++ b/utils.py
@@ -62,8 +62,3 @@ def upload_json(bucket, key, endpoint_url, dictionary, indent=4):
     obj = s3.Object(bucket, key)
 
     obj.put(Body=(bytes(json.dumps(dictionary, indent=indent).encode('UTF-8'))))
-
-
-if __name__ == '__main__':
-    endpoint = 'https://bucket.vpce-0a9b8c4b880602f6e-w4s7h1by.s3.eu-west-1.vpce.amazonaws.com'
-    upload_json("s3-staging-area", "AaronFishman/temp2.json", endpoint, {"cat": "meow"})

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,8 @@
-import boto3
-import botocore
+import json
 import subprocess
 
-
+import boto3
+import botocore
 
 def s3_object_exists(bucket, key, endpoint_url):
     """
@@ -48,5 +48,21 @@ def s3_sync(src_dir, bucket, key, s3_endpoint_url):
     if return_code:
         raise Exception('aws s3 sync failed: %s'%(return_code))
 
+def upload_json(bucket, key, dictionary, endpoint_url, indent=4):
+    """
+        Upload json data to s3
+
+        bucket: S3 Bucket Name
+        key: S3 key the json file is stored under
+        dictionary: A python containing data to be serialised into json for upload
+        endpoint_url: S3 endpoint url
+        indent: Number of indentation spaces in the json
+    """
+    s3 = boto3.resource('s3', endpoint_url=endpoint_url)
+    obj = s3.Object(bucket, key)
+    
+    obj.put(Body=(bytes(json.dumps(dictionary, indent=indent).encode('UTF-8'))))
+
+
 if __name__ == '__main__':
-    print('key exists: ', s3_object_exists('s3-csu-003', 'aaron/'))
+    upload_json("s3-staging-area", "AaronFishman/temp.json", {"Yo": "Dawg"})

--- a/utils.py
+++ b/utils.py
@@ -48,7 +48,7 @@ def s3_sync(src_dir, bucket, key, s3_endpoint_url):
     if return_code:
         raise Exception('aws s3 sync failed: %s'%(return_code))
 
-def upload_json(bucket, key, dictionary, endpoint_url, indent=4):
+def upload_json(bucket, key, endpoint_url, dictionary, indent=4):
     """
         Upload json data to s3
 
@@ -60,9 +60,10 @@ def upload_json(bucket, key, dictionary, endpoint_url, indent=4):
     """
     s3 = boto3.resource('s3', endpoint_url=endpoint_url)
     obj = s3.Object(bucket, key)
-    
+
     obj.put(Body=(bytes(json.dumps(dictionary, indent=indent).encode('UTF-8'))))
 
 
 if __name__ == '__main__':
-    upload_json("s3-staging-area", "AaronFishman/temp.json", {"Yo": "Dawg"})
+    endpoint = 'https://bucket.vpce-0a9b8c4b880602f6e-w4s7h1by.s3.eu-west-1.vpce.amazonaws.com'
+    upload_json("s3-staging-area", "AaronFishman/temp2.json", endpoint, {"cat": "meow"})


### PR DESCRIPTION
Automatically upload json metadata to s3. This makes automation much easier as we no longer have to do lots of complicated regex parsing! I've tested the upload part works on wey-001

- `meta.json` file uploads on every plate directory with fields: project_code / instrument_id / run_number / upload_time
- `upload_json` utility for uploading json to S3
- updated unit tests