### PR TITLE
screen

### DIFF
--- a/launch.bash
+++ b/launch.bash
@@ -11,5 +11,4 @@ set -eo pipefail
 
 JOB_ID=$1
 
-bash install.bash
-python3 launch.py $JOB_ID
+screen -m bash -c "bash install.bash; python3 launch.py $JOB_ID; exec sh"


### PR DESCRIPTION
A `screen` window for the launch script. This way we can leave the ssh sessions for the job machines while they run. 