### PR TITLE
Fix S3 upload

### DIFF
--- a/launch.bash
+++ b/launch.bash
@@ -11,4 +11,4 @@ set -eo pipefail
 
 JOB_ID=$1
 
-screen -m bash -c "bash install.bash; python3 launch.py $JOB_ID; exec sh"
+screen -m bash -c "bash install.bash; sudo python3 launch.py $JOB_ID; exec bash"


### PR DESCRIPTION
Running `python3` with sudo fixes the permission error on uploading sequenced data to s3 in `launch.py`.