### PR TITLE
Reprocess - edits

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -34,8 +34,8 @@ def launch(job_id, results_prefix_uri=DEFAULT_RESULTS_PREFIX_URI, batches_uri=DE
                 bucket: {batch["bucket"]}
                 prefix: {batch["prefix"]}
         """)
-        reads_uri = f's3://{batch["bucket"]}/{batch["prefix"]}'
-        results_uri = f'{results_prefix_uri}/{batch["prefix"]}/'
+        reads_uri = os.path.join(f's3://{batch["bucket"]}',batch["prefix"])
+        results_uri = os.path.join(results_prefix_uri, batch["prefix"])
         
         try:
             run_pipeline_s3(reads_uri, results_uri)

--- a/launch.py
+++ b/launch.py
@@ -23,7 +23,7 @@ def launch(job_id, results_prefix_uri=DEFAULT_RESULTS_PREFIX_URI, batches_uri=DE
 
     # Download batches csv from S3
     logging.info(f"Downloading batches csv from {batches_uri}")
-    #subprocess.run(["aws", "s3", "cp", batches_uri, "./batches.csv"])
+    subprocess.run(["aws", "s3", "cp", batches_uri, "./batches.csv"])
     batches = pd.read_csv('./batches.csv')
     batches = batches.loc[batches.job_id==job_id, :].reset_index(level=0)
 

--- a/launch.py
+++ b/launch.py
@@ -85,17 +85,11 @@ def run_pipeline(reads, results, image=DEFAULT_IMAGE):
 
     # pull and run
     subprocess.run(["sudo", "docker", "pull", image], check=True)
-    try:
-        ps = subprocess.run(["sudo", "docker", "run", "--rm", "-it",
-                             "-v", f"{reads}:/reads/",
-                             "-v", f"{results}:/results/",
-                             image, "bash", "./btb-seq", "/reads/", "/results/",], 
-                             check=True)#, capture_output=True)
-        #print(ps.stdout.decode())
-
-    except subprocess.CalledProcessError as process_error:
-        raise Exception(f"\nfailed process: \n\t'{process_error.cmd}' \n\nexit code: \n\t'{process_error.returncode}' \n\n"
-              f"output: \n\t'{process_error.stdout.decode()}'\n\n")
+    ps = subprocess.run(["sudo", "docker", "run", "--rm", "-it",
+                         "-v", f"{reads}:/reads/",
+                         "-v", f"{results}:/results/",
+                         image, "bash", "./btb-seq", "/reads/", "/results/",], 
+                         check=True)
 
 def main(args):
     # Parse

--- a/launch.py
+++ b/launch.py
@@ -25,7 +25,6 @@ def launch(job_id, results_prefix_uri=DEFAULT_RESULTS_PREFIX_URI, batches_uri=DE
     logging.info(f"Downloading batches csv from {batches_uri}")
     #subprocess.run(["aws", "s3", "cp", batches_uri, "./batches.csv"])
     batches = pd.read_csv('./batches.csv')
-    job_id = 1
     batches = batches.loc[batches.job_id==job_id, :].reset_index(level=0)
 
     # Process one plate at a time

--- a/launch.py
+++ b/launch.py
@@ -42,6 +42,7 @@ def launch(job_id, results_prefix_uri=DEFAULT_RESULTS_PREFIX_URI, batches_uri=DE
 
         except Exception as e:
             logging.exception(e)
+            raise e
 
 def run_pipeline_s3(reads_uri, results_uri, image=DEFAULT_IMAGE):
     """ Run pipeline from S3 uris """

--- a/launch.py
+++ b/launch.py
@@ -13,12 +13,9 @@ from s3_logging_handler import S3LoggingHandler
 
 # TODO: set image to prod
 DEFAULT_IMAGE = "aphacsubot/btb-seq:master"
-#DEFAULT_RESULTS_PREFIX_URI = "s3://s3-csu-003/v3/"
-DEFAULT_RESULTS_PREFIX_URI = "s3://s3-staging-area/nickpestell/v3/"
+DEFAULT_RESULTS_PREFIX_URI = "s3://s3-csu-003/v3/"
 DEFAULT_BATCHES_URI = "s3://s3-csu-001/config/batches.csv"
-#LOGGING_BUCKET = "s3-csu-001"
-LOGGING_BUCKET = "s3-staging-area"
-#LOGGING_PREFIX = "logs/"
+LOGGING_BUCKET = "s3-csu-001"
 LOGGING_PREFIX = "logs"
 
 def launch(job_id, results_prefix_uri=DEFAULT_RESULTS_PREFIX_URI, batches_uri=DEFAULT_BATCHES_URI):


### PR DESCRIPTION
This PR makes some small changes to the reprocess `launch.py`.  

It tidies up the the paths in the output s3 bucket to avoid additional `/`.

It also raises any errors that occur as a result of running `run_pipeline_s3`. I think this is better because any failures will be easily picked up because the script will exit and the last output in the log will be the error. Therefore, the error can be rectified and hopefully the reprocess job can be picked up where it's left off. 