### PR TITLE
Sequenced summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ sudo bash launch.bash job_id
 
 ### (5) Concatenate summary csv files
 
-Each job machine will create a summary csv file which it appends to after each batch run. This is pushed to `s3://s3-csu-003/v3/summary/<job-id>.csv` at the end of the last batch. This CSV file contains relevant metadata for every sample's raw-reads and sequenced results including s3-uris for both. 
+Each job machine will create a summary csv file which it appends to after each batch run. This is pushed to `s3://s3-csu-003/v3/summary/<job-id>.csv` at the end of the last batch. This csv file contains relevant metadata for every sample's raw-reads and sequenced results including s3-uris for both. 
 
 When the last job machine has finished and all samples have been processed, the csv files for each job machine should be concatenated into a single csv file with a row for every sample that was processed. It will contain the following column names:
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ When updating / running the bcl manager in production, it is essential to protec
 4. Perform any maintainance tasks, e.g. software updates
 5. Ensure unit tests pass
 ```
-python unit_tests.py
+python unit_tests.py -m bcl_manager
 ......
 ----------------------------------------------------------------------
 Ran 6 tests in 0.022s
@@ -174,6 +174,7 @@ To reprocess the TB samples:
 2. Plan how jobs will be delegated to machines by adding a `job_id` column to the `batches.csv` file
 3. Configure the `launch.py` script
 4. Launch jobs on EC2 machines
+5. Concatenate summary csv files
 
 See below for details on how to perform each step. 
 
@@ -232,3 +233,9 @@ aws s3 cp --recursive s3://s3-csu-001/sequence-manager ./
 sudo bash launch.bash job_id
 ```
 - this will start a new screen session: once dependencies are installed and the first plate is running in Nextflow, detached from the screen (crtl+a d) and close the SSH session
+
+### (5) Concatenate summary csv files
+
+Each job machine will create a summary csv file which it appends to after each batch run. This is pushed to `s3://s3-csu-003/v3/summary/<job-id>.csv` at the end of the last batch. This CSV file contains relevant metadata for every sample's raw-reads and sequenced results including s3-uris for both. 
+
+When the last job machine has finished and all samples have been processed, the csv files for each job machine should be concatenated into a single csv file with a row for every sample that was processed. It will contain the following column names: sample_name, submission, project_code sequencer, run_id, well, read_1, read_2, lane, batch_id, reads_bucket, results_bucket results_prefix, sequenced_datetime, GenomeCov, MeanDepth, NumRawReads, pcMapped, Outcome, flag, group, CSSTested, matches, mismatches, noCoverage, anomalous.

--- a/README.md
+++ b/README.md
@@ -238,4 +238,8 @@ sudo bash launch.bash job_id
 
 Each job machine will create a summary csv file which it appends to after each batch run. This is pushed to `s3://s3-csu-003/v3/summary/<job-id>.csv` at the end of the last batch. This CSV file contains relevant metadata for every sample's raw-reads and sequenced results including s3-uris for both. 
 
-When the last job machine has finished and all samples have been processed, the csv files for each job machine should be concatenated into a single csv file with a row for every sample that was processed. It will contain the following column names: sample_name, submission, project_code sequencer, run_id, well, read_1, read_2, lane, batch_id, reads_bucket, results_bucket results_prefix, sequenced_datetime, GenomeCov, MeanDepth, NumRawReads, pcMapped, Outcome, flag, group, CSSTested, matches, mismatches, noCoverage, anomalous.
+When the last job machine has finished and all samples have been processed, the csv files for each job machine should be concatenated into a single csv file with a row for every sample that was processed. It will contain the following column names:
+
+```
+sample_name | submission | project_code | sequencer | run_id | well | read_1 | read_2 | lane | batch_id | reads_bucket | results_bucket | results_prefix | sequenced_datetime | GenomeCov | MeanDepth | NumRawReads | pcMapped | Outcome | flag | group | CSSTested | matches | mismatches | noCoverage | anomalous
+```

--- a/launch.py
+++ b/launch.py
@@ -107,6 +107,12 @@ def run_pipeline(reads, results, image=DEFAULT_IMAGE):
                          image, "bash", "./btb-seq", "/reads/", "/results/",], 
                          check=True)
 
+#TODO: make pass unit tests
+def extract_submission_no(sample_name):
+    """ Extracts submision number from sample name using regex """
+    pattern = r'^AF[\w]*-'
+    return re.sub(pattern, "", sample_name)
+
 def append_summary(batch, results_prefix, summary_filepath, work_dir):
     """
         Appends to a summary csv file containing metadata for each sample including reads and results
@@ -118,8 +124,7 @@ def append_summary(batch, results_prefix, summary_filepath, work_dir):
     assigned_wgs_cluster_path = glob.glob(f'{results_path}/*AssignedWGSCluster*.csv')
     df = pd.read_csv(assigned_wgs_cluster_path[0])
     # add columns for reads and results URIs
-    pattern = r'^AF[A-Z]-|^AF-'
-    df.insert(1, 'Submission', df['Sample'].map(lambda x: re.sub(pattern, "", x)))
+    df.insert(1, 'Submission', df['Sample'].map(extract_submission_no))
     df.insert(2, "reads_bucket", batch["bucket"])
     df.insert(3, "reads_prefix", batch["prefix"])
     df.insert(4, "project_code", batch["prefix"].split("/")[0])

--- a/launch.py
+++ b/launch.py
@@ -110,7 +110,13 @@ def run_pipeline(reads, results, image=DEFAULT_IMAGE):
 #TODO: make pass unit tests
 def extract_submission_no(sample_name):
     """ Extracts submision number from sample name using regex """
-    pattern = r'^AF[\w]*-'
+    # NOTE: Only extracts the sample number from correctly formatted
+    # sample names (AF(xx)-)nn-(n)nnnn-yy, where brackets are optional.
+    # E.g. AFTa-98-12345-21 -> 98-12345-21 | 98-12345-21 -> 98-12345-21 | 
+    # 123456789 -> 123456789. If the sample name is formattted incorectly,
+    # e.g. AT98-12345-21 | AFT98-12345-21 | A-98-12345-21 this is likely 
+    # to remain unchanged. 
+    pattern = r'^AF[\w]{0,2}-|^HI-'
     return re.sub(pattern, "", sample_name)
 
 def append_summary(batch, results_prefix, summary_filepath, work_dir):

--- a/launch.py
+++ b/launch.py
@@ -18,13 +18,13 @@ import summary
 
 # TODO: set image to prod
 DEFAULT_IMAGE = "aphacsubot/btb-seq:master"
-DEFAULT_RESULTS_BUCKET = "s3-staging-area"
-DEFAULT_RESULTS_S3_PATH = "nickpestell/v3"
+DEFAULT_RESULTS_BUCKET = "s3-csu-003"
+DEFAULT_RESULTS_S3_PATH = "v3"
 DEFAULT_BATCHES_URI = "s3://s3-csu-001/config/batches.csv"
-DEFAULT_SUMMARY_PREFIX = "nickpestell/v3/summary" 
-DEFAULT_SUMMARY_FILEPATH = os.path.join(os.getcwd(), "summary.csv")
-LOGGING_BUCKET = "s3-staging-area"
+DEFAULT_SUMMARY_PREFIX = "v3/summary" 
+LOGGING_BUCKET = "s3-csu-003"
 LOGGING_PREFIX = "logs"
+DEFAULT_SUMMARY_FILEPATH = os.path.join(os.getcwd(), "summary.csv")
 
 def launch(job_id, results_bucket=DEFAULT_RESULTS_BUCKET, results_s3_path=DEFAULT_RESULTS_S3_PATH, 
            batches_uri=DEFAULT_BATCHES_URI, summary_prefix=DEFAULT_SUMMARY_PREFIX, 
@@ -33,7 +33,7 @@ def launch(job_id, results_bucket=DEFAULT_RESULTS_BUCKET, results_s3_path=DEFAUL
 
     # Download batches csv from S3
     logging.info(f"Downloading batches csv from {batches_uri}")
-    #subprocess.run(["aws", "s3", "cp", batches_uri, "./batches.csv"])
+    subprocess.run(["aws", "s3", "cp", batches_uri, "./batches.csv"])
     batches = pd.read_csv('./batches.csv')
     batches = batches.loc[batches.job_id==job_id, :].reset_index(level=0)
 

--- a/launch.py
+++ b/launch.py
@@ -125,7 +125,7 @@ def append_summary(batch, results_prefix, summary_filepath, work_dir):
     df_results.insert(2, "results_prefix", os.path.join(results_prefix, results_path.split(os.path.sep)[-1]))
     df_results.insert(3, "sequenced_datetime", time.strftime("%d-%m-%y %H:%M:%S"))
     # join reads and results dataframes
-    df_joined = df_reads.join(df_results.set_index('Sample'), on='sample_name')
+    df_joined = df_reads.join(df_results.set_index('Sample'), on='sample_name', how='outer')
     # if summary file already exists locally - append to existing file
     if os.path.exists(summary_filepath):
         df_summary = pd.read_csv(summary_filepath)

--- a/launch.py
+++ b/launch.py
@@ -113,11 +113,11 @@ def extract_submission_no(sample_name):
     # NOTE: Only extracts the sample number from correctly formatted
     # sample names (AF(xx)-)nn-(n)nnnn-yy, where brackets are optional.
     # E.g. AFTa-98-12345-21 -> 98-12345-21 | 98-12345-21 -> 98-12345-21 | 
-    # 123456789 -> 123456789. If the sample name is formattted incorectly,
-    # e.g. AT98-12345-21 | AFT98-12345-21 | A-98-12345-21 this is likely 
-    # to remain unchanged. 
-    pattern = r'^AF[\w]{0,2}-|^HI-'
-    return re.sub(pattern, "", sample_name)
+    # 123456789 -> 123456789.
+    pattern = r'\d{2,2}-\d{4,5}-\d{2,2}'
+    matches = re.findall(pattern, sample_name)
+    submission_no = matches[0] if matches else sample_name
+    return submission_no
 
 def append_summary(batch, results_prefix, summary_filepath, work_dir):
     """

--- a/launch.py
+++ b/launch.py
@@ -7,6 +7,7 @@ import tempfile
 import logging
 import glob
 import time
+import re
 
 import pandas as pd
 
@@ -117,7 +118,8 @@ def append_summary(batch, results_prefix, summary_filepath, work_dir):
     assigned_wgs_cluster_path = glob.glob(f'{results_path}/*AssignedWGSCluster*.csv')
     df = pd.read_csv(assigned_wgs_cluster_path[0])
     # add columns for reads and results URIs
-    df.insert(1, 'Submission', df['Sample'].map(lambda x: "-".join(x.split("-")[1:])))
+    pattern = r'^AF[A-Z]-|^AF-'
+    df.insert(1, 'Submission', df['Sample'].map(lambda x: re.sub(pattern, "", x)))
     df.insert(2, "reads_bucket", batch["bucket"])
     df.insert(3, "reads_prefix", batch["prefix"])
     df.insert(4, "project_code", batch["prefix"].split("/")[0])

--- a/launch.py
+++ b/launch.py
@@ -108,24 +108,13 @@ def run_pipeline(reads, results, image=DEFAULT_IMAGE):
                          image, "bash", "./btb-seq", "/reads/", "/results/",], 
                          check=True)
 
-def extract_submission_no(sample_name):
-    """ Extracts submision number from sample name using regex """
-    # NOTE: Only extracts the sample number from correctly formatted
-    # sample names (AF(xx)-)nn-(n)nnnn-yy, where brackets are optional.
-    # E.g. AFTa-98-12345-21 -> 98-12345-21 | 98-12345-21 -> 98-12345-21 | 
-    # 123456789 -> 123456789.
-    pattern = r'\d{2,2}-\d{4,5}-\d{2,2}'
-    matches = re.findall(pattern, sample_name)
-    submission_no = matches[0] if matches else sample_name
-    return submission_no
-
 def append_summary(batch, results_prefix, summary_filepath, work_dir):
     """
         Appends to a summary csv file containing metadata for each sample including reads and results
         s3 URIs.
     """
     # get reads metadata
-    df_reads, _, _, _ = summary.bucket_summary(batch["bucket"], batch["prefix"])
+    df_reads, _, _, _ = summary.bucket_summary(batch["bucket"], [batch["prefix"]])
     # download metadata for the batch from AssignedWGSCluster csv file
     results_path = glob.glob(f'{work_dir}/results/Results*')
     results_path = results_path[0]

--- a/summary.py
+++ b/summary.py
@@ -82,10 +82,10 @@ def pair_files(keys):
         # Create Sample Object
         sample = {
             "sample_name": match_1[3],
+            "submission": extract_submission_no(match_1[3]),
             "project_code": match_1[0],
             "sequencer": match_1[1] if match_1[1] else "UnknownSequencer",
             "run_id": match_1[2],
-            "submission": extract_submission_no(match_1[3]),
             "well": match_1[4],
             "read_1": key_1,
             "read_2": key_2,
@@ -142,7 +142,7 @@ def bucket_summary(bucket, prefixes):
     samples, batches, unpaired, not_parsed = pair_files(keys)
 
     # Include bucket name
-    samples["bucket"] = bucket
+    samples["reads_bucket"] = bucket
     batches["bucket"] = bucket
     unpaired["bucket"] = bucket
     not_parsed["bucket"] = bucket

--- a/summary.py
+++ b/summary.py
@@ -85,6 +85,7 @@ def pair_files(keys):
             "sequencer": match_1[1] if match_1[1] else "UnknownSequencer",
             "run_id": match_1[2],
             "name": match_1[3],
+            "submission": extract_submission_no(match_1[3]),
             "well": match_1[4],
             "read_1": key_1,
             "read_2": key_2,
@@ -147,6 +148,13 @@ def bucket_summary(bucket, prefixes):
     not_parsed["bucket"] = bucket
 
     return samples, batches, unpaired, not_parsed
+
+def extract_submission_no(sample_name):
+    """ Extracts submision number from sample name using regex """
+    pattern = r'\d{2,2}-\d{4,5}-\d{2,2}'
+    matches = re.findall(pattern, sample_name)
+    submission_no = matches[0] if matches else sample_name
+    return submission_no
 
 def main():
     """ summarises the TB samples. Produces a number of csvs locally """

--- a/summary.py
+++ b/summary.py
@@ -81,10 +81,10 @@ def pair_files(keys):
 
         # Create Sample Object
         sample = {
+            "sample_name": match_1[3],
             "project_code": match_1[0],
             "sequencer": match_1[1] if match_1[1] else "UnknownSequencer",
             "run_id": match_1[2],
-            "name": match_1[3],
             "submission": extract_submission_no(match_1[3]),
             "well": match_1[4],
             "read_1": key_1,
@@ -163,7 +163,7 @@ def main():
     samples_2, batches_2, unpaired_2, not_parsed_2 = bucket_summary('s3-csu-002', ['SB4020-TB/'])
 
     # Combine + csv output
-    pd.concat([samples_1, samples_2], ignore_index=True).to_csv('samples.csv')
+    pd.concat([samples_1, samples_2], ignore_index=True).to_csv('samples.csv', index=False)
     pd.concat([batches_1, batches_2], ignore_index=True).to_csv('batches.csv')
     pd.concat([unpaired_1, unpaired_2], ignore_index=True).to_csv('unpaired.csv')
     pd.concat([not_parsed_1, not_parsed_2], ignore_index=True).to_csv('not_parsed.csv')

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -142,7 +142,7 @@ class TestBclManager(unittest.TestCase):
         with self.assertRaises(Exception):
             bcl_manager.upload(bad_src_path, '', '', '')
 
-class TestLaunch(unittest.TestCase):
+class TestSummary(unittest.TestCase):
     def test_extract_submission_no(self):
         # Test cases
         # NOTE: only tests for removing preceeding AFxx from correctly formatted
@@ -191,22 +191,22 @@ class TestLaunch(unittest.TestCase):
                        "12-34567-89",
                        "12-34567-89",
                        "12-3456-89",
-                       "12-3456-89",
-                       "12-3456-89",
-                       "12-3456-89",
-                       "12-3456-89",
-                       "12-3456-89",
-                       "12-3456-89",
-                       "12-3456-89",
-                       "12-3456-89",
-                       "12-3456-89",
-                       "12-3456-89",
-                       "12-3456-89",
-                       "12-3456-89",
-                       "12345678",
-                       "ABCDEFGH",
-                       ""]
-        fail = False
+                       "12-3456-89", 
+                       "12-3456-89", 
+                       "12-3456-89", 
+                       "12-3456-89", 
+                       "12-3456-89", 
+                       "12-3456-89", 
+                       "12-3456-89", 
+                       "12-3456-89", 
+                       "12-3456-89", 
+                       "12-3456-89", 
+                       "12-3456-89", 
+                       "12-3456-89", 
+                       "12345678", 
+                       "ABCDEFGH", 
+                       ""] 
+        fail = False 
         i = 0
         for input, output in zip(test_input, test_output):
             try:
@@ -230,19 +230,19 @@ if __name__ == '__main__':
                         TestBclManager('test_start'),
                         TestBclManager('test_convert_to_fastq'),
                         TestBclManager('test_upload')]
-    launch_test = [TestLaunch('test_extract_submission_no')]
+    summary_test = [TestSummary('test_extract_submission_no')]
     runner = unittest.TextTestRunner()
     parser = argparse.ArgumentParser(description='Test code')
     module_arg = parser.add_argument('--module', '-m', nargs=1, 
-                                     help="module to test: 'bcl_manager' or 'launch'",
+                                     help="module to test: 'bcl_manager' or 'summary'",
                                      default=None)
     args = parser.parse_args()
     try:
         if args.module:
             if args.module[0] == 'bcl_manager':
                 runner.run(test_suit(bcl_manager_test)) 
-            elif args.module[0] == 'launch':
-                runner.run(test_suit(launch_test)) 
+            elif args.module[0] == 'summary':
+                runner.run(test_suit(summary_test)) 
             else:
                 raise argparse.ArgumentError(module_arg, "Invalid argument. Please use 'forward', 'reverse' or 'interface'")
         else:

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -144,17 +144,25 @@ class TestBclManager(unittest.TestCase):
 
 class TestLaunch(unittest.TestCase):
     def test_extract_submission_no(self):
+        # Test cases
+        # NOTE: only tests for removing preceeding AFxx from correctly formatted
+        # sample name. If the sample name is formattted incorectly, unexpected 
+        # behaviour may occur.
         test_input = ["AFxx-nn-nnnnn-yy",
                       "ATxx-nn-nnnnn-yy",
                       "AFx-nn-nnnnn-yy",
                       "Ax-nn-nnnnn-yy",
                       "AF-nn-nnnnn-yy",
                       "AFxnn-nnnnn-yy",
+                      "HI-12-3456-91",
                       "A-nn-nnnnn-yy",
-                      "-nn-nnnnn-yy",
+                      "nn-nnnnn-yy",
                       "nn-nnnnn-yy",
                       "12345678",
                       "ABCDEFGH",
+                      "HBCDEFGH",
+                      "HI-CDEFGH",
+                      "HICDEFGH",
                       ""]
         test_output = ["nn-nnnnn-yy",
                        "ATxx-nn-nnnnn-yy",
@@ -162,11 +170,15 @@ class TestLaunch(unittest.TestCase):
                        "Ax-nn-nnnnn-yy",
                        "nn-nnnnn-yy",
                        "AFxnn-nnnnn-yy",
+                       "12-3456-91",
                        "A-nn-nnnnn-yy",
-                       "-nn-nnnnn-yy",
+                       "nn-nnnnn-yy",
                        "nn-nnnnn-yy",
                        "12345678",
                        "ABCDEFGH",
+                       "HBCDEFGH",
+                       "CDEFGH",
+                       "HICDEFGH",
                        ""]
         for input, output in zip(test_input, test_output):
             self.assertEqual(launch.extract_submission_no(input), output)

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -145,9 +145,6 @@ class TestBclManager(unittest.TestCase):
 class TestSummary(unittest.TestCase):
     def test_extract_submission_no(self):
         # Test cases
-        # NOTE: only tests for removing preceeding AFxx from correctly formatted
-        # sample name. If the sample name is formattted incorectly, unexpected 
-        # behaviour may occur.
         test_input = ["AFxx-12-34567-89",
                       "ATxx-12-34567-89",
                       "AFx-12-34567-89",

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -148,40 +148,76 @@ class TestLaunch(unittest.TestCase):
         # NOTE: only tests for removing preceeding AFxx from correctly formatted
         # sample name. If the sample name is formattted incorectly, unexpected 
         # behaviour may occur.
-        test_input = ["AFxx-nn-nnnnn-yy",
-                      "ATxx-nn-nnnnn-yy",
-                      "AFx-nn-nnnnn-yy",
-                      "Ax-nn-nnnnn-yy",
-                      "AF-nn-nnnnn-yy",
-                      "AFxnn-nnnnn-yy",
-                      "HI-12-3456-91",
-                      "A-nn-nnnnn-yy",
-                      "nn-nnnnn-yy",
-                      "nn-nnnnn-yy",
+        test_input = ["AFxx-12-34567-89",
+                      "ATxx-12-34567-89",
+                      "AFx-12-34567-89",
+                      "Ax-12-34567-89",
+                      "AF-12-34567-89",
+                      "AFx12-34567-89",
+                      "HI-12-34567-89",
+                      "12-34567-89-1L",
+                      "12-34567-89-L1",
+                      "A-12-34567-89",
+                      "12-34567-89-1",
+                      "12-34567-89-L",
+                      "12-34567-89",
+                      "AFxx-12-3456-89",
+                      "ATxx-12-3456-89",
+                      "AFx-12-3456-89",
+                      "Ax-12-3456-89",
+                      "AF-12-3456-89",
+                      "AFx12-3456-89",
+                      "HI-12-3456-89",
+                      "12-3456-89-1L",
+                      "12-3456-89-L1",
+                      "A-12-3456-89",
+                      "12-3456-89-1",
+                      "12-3456-89-L",
+                      "12-3456-89",
                       "12345678",
                       "ABCDEFGH",
-                      "HBCDEFGH",
-                      "HI-CDEFGH",
-                      "HICDEFGH",
                       ""]
-        test_output = ["nn-nnnnn-yy",
-                       "ATxx-nn-nnnnn-yy",
-                       "nn-nnnnn-yy",
-                       "Ax-nn-nnnnn-yy",
-                       "nn-nnnnn-yy",
-                       "AFxnn-nnnnn-yy",
-                       "12-3456-91",
-                       "A-nn-nnnnn-yy",
-                       "nn-nnnnn-yy",
-                       "nn-nnnnn-yy",
+        test_output = ["12-34567-89",
+                       "12-34567-89",
+                       "12-34567-89",
+                       "12-34567-89",
+                       "12-34567-89",
+                       "12-34567-89",
+                       "12-34567-89",
+                       "12-34567-89",
+                       "12-34567-89",
+                       "12-34567-89",
+                       "12-34567-89",
+                       "12-34567-89",
+                       "12-34567-89",
+                       "12-3456-89",
+                       "12-3456-89",
+                       "12-3456-89",
+                       "12-3456-89",
+                       "12-3456-89",
+                       "12-3456-89",
+                       "12-3456-89",
+                       "12-3456-89",
+                       "12-3456-89",
+                       "12-3456-89",
+                       "12-3456-89",
+                       "12-3456-89",
+                       "12-3456-89",
                        "12345678",
                        "ABCDEFGH",
-                       "HBCDEFGH",
-                       "CDEFGH",
-                       "HICDEFGH",
                        ""]
+        fail = False
+        i = 0
         for input, output in zip(test_input, test_output):
-            self.assertEqual(launch.extract_submission_no(input), output)
+            try:
+                self.assertEqual(launch.extract_submission_no(input), output)
+            except AssertionError as e:
+                i += 1
+                fail = True
+                print(f"Test failure {i}: ", e)
+        if fail: 
+            print(f"{i} test failures")
+            raise AssertionError
 
 def test_suit(test_objs):
     suit = unittest.TestSuite(test_objs)

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -179,8 +179,6 @@ if __name__ == '__main__':
     bcl_manager_test = [TestBclManager('test_handler_construction'),
                         TestBclManager('test_on_create'),
                         TestBclManager('test_copy'),
-                        # TODO: need to work out how to add positional arguments
-                        TestBclManager('assertOnCreatedProcessing'),
                         TestBclManager('test_start'),
                         TestBclManager('test_convert_to_fastq'),
                         TestBclManager('test_upload')]


### PR DESCRIPTION
This PR adds an additional output to the re-process workflow which is a set of summary CSV files for each job machine which runs during the reprocess. This CSV file will have the following column headers:

```
sample_name | submission | project_code | sequencer | run_id | well | read_1 | read_2 | lane | batch_id | reads_bucket | results_bucket | results_prefix | sequenced_datetime | GenomeCov | MeanDepth | NumRawReads | pcMapped | Outcome | flag | group | CSSTested | matches | mismatches | noCoverage | anomalous
```

This is essentially an amalgamation of Aaron's `samples.csv` file generated in `summary.py` and the `AssignWGSClusters.csv` generated for each batch of the pipeline run. 

The multiple CSV file output should be manually concatenated at the end of the reprocess to generate a giant `summary.csv` for every sample. 

This will be useful for selecting samples for `btb-phylo` and `ViewBovine` as well as for general data-management going forward, particularly to improve traceability from raw-reads to sequenced data (particularly the s3-locations).

The main changes are to `launch.py` which is code for performing the reprocess.

Some small changes have been made to `summary.py` to add a column for `submission` number to `samples.csv` and an additional unittest to test the regex pattern.

Please pay particular attention to the method of "joining" the reads and results dataframes on L128 in `launch.py`, as I'm not that confident with pandas, and the different types of joining. The intention is to join the two dataframes by matching the columns "sample_name" and "Sample"
. @CameroneN I think pandas is a bit similar to sql in this regard so thought you might know.
