### PR TITLE
Direct s3

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -28,6 +28,7 @@ sudo apt-get -y install docker-ce \
 			docker-compose-plugin
 sudo groupadd docker
 sudo usermod -aG docker $USER
+newgrp docker
 
 # python 
 pip3 install biopython numpy pandas gitpython boto3

--- a/install.bash
+++ b/install.bash
@@ -13,7 +13,8 @@ sudo apt-get -y install python3 \
     			ca-certificates \
 	        	curl \
 		    	gnupg \
-		        lsb-release
+		        lsb-release \
+			openjdk-11-jdk
 
 
 # docker
@@ -25,8 +26,13 @@ sudo apt-get -y install docker-ce \
 			docker-ce-cli \
 			containerd.io \
 			docker-compose-plugin
+sudo groupadd docker
+sudo usermod -aG docker $USER
 
 # python 
 pip3 install biopython numpy pandas gitpython boto3
 pip3 install --upgrade awscli
+
+# nextflow
+curl -s https://get.nextflow.io | bash
 

--- a/launch.py
+++ b/launch.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from s3_logging_handler import S3LoggingHandler
 import summary
+import utils
 
 # Launch and manage jobs for the TB reprocess
 
@@ -21,14 +22,26 @@ DEFAULT_IMAGE = "aphacsubot/btb-seq:master"
 #DEFAULT_RESULTS_BUCKET = "s3-csu-003"
 DEFAULT_RESULTS_BUCKET = "s3-staging-area"
 #DEFAULT_RESULTS_S3_PATH = "v3"
-DEFAULT_RESULTS_S3_PATH = "nickpestell/v3"
+DEFAULT_RESULTS_S3_PATH = "nickpestell/v8"
 DEFAULT_BATCHES_URI = "s3://s3-csu-001/config/batches.csv"
 #DEFAULT_SUMMARY_PREFIX = "v3/summary" 
-DEFAULT_SUMMARY_PREFIX = "nickpestell/v3/summary" 
+DEFAULT_SUMMARY_PREFIX = "nickpestell/v8/summary" 
 #LOGGING_BUCKET = "s3-csu-003"
 LOGGING_BUCKET = "s3-staging-area"
 LOGGING_PREFIX = "nickpestell/logs"
 DEFAULT_SUMMARY_FILEPATH = os.path.join(os.getcwd(), "summary.csv")
+
+def s3_download_file(bucket, key, dest):
+    """
+        Downloads s3 folder at the key-bucket pair (strings) to dest 
+        path (string)
+    """
+    if s3_object_exists(bucket, key):
+        s3 = boto3.client('s3')
+        s3.download_file(bucket, key, dest)
+    else:
+        raise NoS3ObjectError(bucket, key)
+
 
 def launch(job_id, results_bucket=DEFAULT_RESULTS_BUCKET, results_s3_path=DEFAULT_RESULTS_S3_PATH, 
            batches_uri=DEFAULT_BATCHES_URI, summary_prefix=DEFAULT_SUMMARY_PREFIX, 
@@ -89,7 +102,7 @@ def run_pipeline(reads_uri, results_uri, run_id):
     """ Run the pipeline using docker """
 
     # pull and run
-    cmd = f'nextflow run APHA-CSU/btb-seq -with-docker aphacsubot/btb-seq -r prod --reads="{reads_uri}*_{{S*_R1,S*_R2}}_*.fastq.gz" --outdir="{results_uri}"'
+    cmd = f'nextflow run APHA-CSU/btb-seq -with-docker aphacsubot/btb-seq -r master --reads="{reads_uri}*_{{S*_R1,S*_R2}}_*.fastq.gz" --outdir="{results_uri}"'
     ps = subprocess.run(cmd, shell=True, check=True)
 
 def append_summary(batch, results_prefix, summary_filepath, results_uri):#work_dir):
@@ -100,16 +113,21 @@ def append_summary(batch, results_prefix, summary_filepath, results_uri):#work_d
     # get reads metadata
     df_reads, _, _, _ = summary.bucket_summary(batch["bucket"], [batch["prefix"]])
     # download metadata for the batch from AssignedWGSCluster csv file
-    with tempfile.TemporaryDirectory() as temp_dirname:
-        print(batch["batch_id"])
-        subprocess.run(["aws", "s3", "cp", "--recursive", "--exclude", '"*"', "--include", f'"{batch["batch_id"]}_FinalOut*.csv"', f'{results_uri}', temp_dirname], check=True)
-        final_out_path = glob.glob(f"{temp_dirname}/Results_*/*FinalOut*.csv")
-        print("FINAL OUT PATH: ", final_out_path)
-        print("BLAR: ", final_out_path[0].split("/")[2])
-        df_results = pd.read_csv(final_out_path[0], comment="#")
+    #with tempfile.TemporaryDirectory() as temp_dirname:
+    temp_file = f"/home/nickpestell/tmp/test{batch['batch_id']}/out.csv"
+    cmd =  f"aws s3 ls --recursive {results_uri}/Results_{batch['batch_id']}_ | grep -e 'FinalOut'"
+    ps = subprocess.run(cmd, shell=True, 
+                        check=True, capture_output=True)
+    final_out_path = ps.stdout.decode().strip('\n').split(' ')[-1]
+    utils.s3_download_file(DEFAULT_RESULTS_BUCKET, final_out_path, temp_file, endpoint_url=None)
+    df_results = pd.read_csv(temp_file, comment="#")
     # add columns for reads and results URIs
+    cmd =  f"aws s3 ls {results_uri}/Results_{batch['batch_id']}_"
+    ps = subprocess.run(cmd, shell=True, 
+                        check=True, capture_output=True)
+    results_prefix = os.path.join(results_prefix, ps.stdout.decode().strip('\n').split(' ')[-1])
     df_results.insert(1, "results_bucket", "s3-csu-003")
-    df_results.insert(2, "results_prefix", os.path.join(results_prefix))#, results_path.split(os.path.sep)[-1]))
+    df_results.insert(2, "results_prefix", results_prefix)#, results_path.split(os.path.sep)[-1]))
     df_results.insert(3, "sequenced_datetime", time.strftime("%d-%m-%y %H:%M:%S"))
     # join reads and results dataframes
     df_joined = df_reads.join(df_results.set_index('Sample'), on='sample_name', how='outer')

--- a/launch.py
+++ b/launch.py
@@ -17,31 +17,13 @@ import utils
 
 # Launch and manage jobs for the TB reprocess
 
-# TODO: set image to prod
-DEFAULT_IMAGE = "aphacsubot/btb-seq:master"
-#DEFAULT_RESULTS_BUCKET = "s3-csu-003"
-DEFAULT_RESULTS_BUCKET = "s3-staging-area"
-#DEFAULT_RESULTS_S3_PATH = "v3"
-DEFAULT_RESULTS_S3_PATH = "nickpestell/v8"
+DEFAULT_RESULTS_BUCKET = "s3-csu-003"
+DEFAULT_RESULTS_S3_PATH = "v3"
 DEFAULT_BATCHES_URI = "s3://s3-csu-001/config/batches.csv"
-#DEFAULT_SUMMARY_PREFIX = "v3/summary" 
-DEFAULT_SUMMARY_PREFIX = "nickpestell/v8/summary" 
-#LOGGING_BUCKET = "s3-csu-003"
-LOGGING_BUCKET = "s3-staging-area"
-LOGGING_PREFIX = "nickpestell/logs"
+DEFAULT_SUMMARY_PREFIX = "v3/summary" 
+LOGGING_BUCKET = "s3-csu-003"
+LOGGING_PREFIX = "v3/logs"
 DEFAULT_SUMMARY_FILEPATH = os.path.join(os.getcwd(), "summary.csv")
-
-def s3_download_file(bucket, key, dest):
-    """
-        Downloads s3 folder at the key-bucket pair (strings) to dest 
-        path (string)
-    """
-    if s3_object_exists(bucket, key):
-        s3 = boto3.client('s3')
-        s3.download_file(bucket, key, dest)
-    else:
-        raise NoS3ObjectError(bucket, key)
-
 
 def launch(job_id, results_bucket=DEFAULT_RESULTS_BUCKET, results_s3_path=DEFAULT_RESULTS_S3_PATH, 
            batches_uri=DEFAULT_BATCHES_URI, summary_prefix=DEFAULT_SUMMARY_PREFIX, 
@@ -50,9 +32,15 @@ def launch(job_id, results_bucket=DEFAULT_RESULTS_BUCKET, results_s3_path=DEFAUL
 
     # Download batches csv from S3
     logging.info(f"Downloading batches csv from {batches_uri}")
-#    subprocess.run(["aws", "s3", "cp", batches_uri, "./batches.csv"])
+    subprocess.run(["aws", "s3", "cp", batches_uri, "./batches.csv"])
     batches = pd.read_csv('./batches.csv')
     batches = batches.loc[batches.job_id==job_id, :].reset_index(level=0)
+
+    df_summary = pd.DataFrame(columns=["sample_name", "submission", "project_code", "sequencer", "run_id",
+                                       "well", "read_1", "read_2", "lane", "batch_id", "reads_bucket", "results_bucket",
+                                       "results_prefix", "sequenced_datetime", "GenomeCov", "MeanDepth", "NumRawReads", 
+                                       "pcMapped", "Outcome", "flag", "group", "CSSTested", "matches", "mismatches",
+                                       "noCoverage", "anomalous", "Ncount", "ID", "TotalReads", "Abundance"])
 
     # Process one plate at a time
     for i, batch in batches.iterrows():
@@ -69,8 +57,8 @@ def launch(job_id, results_bucket=DEFAULT_RESULTS_BUCKET, results_s3_path=DEFAUL
         # temp directory ensures we don't get lots of data accumulating
         with tempfile.TemporaryDirectory() as temp_dirname:
             try:
-                run_pipeline_s3(reads_uri, results_uri, temp_dirname, run_id)
-                append_summary(batch, results_prefix, summary_filepath, results_uri)
+                run_pipeline_s3(reads_uri, results_uri)
+                df_summary = append_summary(df_summary, batch, results_prefix, summary_filepath, results_uri)
 
             except Exception as e:
                 logging.exception(e)
@@ -78,6 +66,7 @@ def launch(job_id, results_bucket=DEFAULT_RESULTS_BUCKET, results_s3_path=DEFAUL
 
     # Push summary csv file to s3
     summary_uri = os.path.join(f's3://{results_bucket}', summary_prefix, f'{job_id}.csv')
+    df_summary.to_csv(summary_filepath, index=False)
     try:
         subprocess.run(["aws", "s3", "cp", "--acl", "bucket-owner-full-control", summary_filepath, summary_uri], check=True)
 
@@ -85,8 +74,8 @@ def launch(job_id, results_bucket=DEFAULT_RESULTS_BUCKET, results_s3_path=DEFAUL
         logging.exception(e)
         raise e
 
-def run_pipeline_s3(reads_uri, results_uri, work_dir, run_id, image=DEFAULT_IMAGE):
-    """ Run pipeline from S3 uris """
+def run_pipeline_s3(reads_uri, results_uri):
+    """ Run pipeline frommS3 uris """
     
     # Validate input
     if not reads_uri.startswith("s3://"):
@@ -95,50 +84,42 @@ def run_pipeline_s3(reads_uri, results_uri, work_dir, run_id, image=DEFAULT_IMAG
     if not results_uri.startswith("s3://"):
         raise Exception(f"Invalid results uri: {results_uri}")
     
-    # Run
-    run_pipeline(reads_uri, results_uri, run_id)
-
-def run_pipeline(reads_uri, results_uri, run_id):
-    """ Run the pipeline using docker """
-
     # pull and run
-    cmd = f'nextflow run APHA-CSU/btb-seq -with-docker aphacsubot/btb-seq -r master --reads="{reads_uri}*_{{S*_R1,S*_R2}}_*.fastq.gz" --outdir="{results_uri}"'
+    cmd = f'nextflow run APHA-CSU/btb-seq -with-docker aphacsubot/btb-seq -r prod --reads="{reads_uri}*_{{S*_R1,S*_R2}}_*.fastq.gz" --outdir="{results_uri}"'
     ps = subprocess.run(cmd, shell=True, check=True)
 
-def append_summary(batch, results_prefix, summary_filepath, results_uri):#work_dir):
+def append_summary(df_summary, batch, results_prefix, summary_filepath, results_uri, results_bucket=DEFAULT_RESULTS_BUCKET):
     """
         Appends to a summary csv file containing metadata for each sample including reads and results
         s3 URIs.
     """
     # get reads metadata
     df_reads, _, _, _ = summary.bucket_summary(batch["bucket"], [batch["prefix"]])
-    # download metadata for the batch from AssignedWGSCluster csv file
-    #with tempfile.TemporaryDirectory() as temp_dirname:
-    temp_file = f"/home/nickpestell/tmp/test{batch['batch_id']}/out.csv"
-    cmd =  f"aws s3 ls --recursive {results_uri}/Results_{batch['batch_id']}_ | grep -e 'FinalOut'"
-    ps = subprocess.run(cmd, shell=True, 
-                        check=True, capture_output=True)
-    final_out_path = ps.stdout.decode().strip('\n').split(' ')[-1]
-    utils.s3_download_file(DEFAULT_RESULTS_BUCKET, final_out_path, temp_file, endpoint_url=None)
-    df_results = pd.read_csv(temp_file, comment="#")
-    # add columns for reads and results URIs
+    # download metadata for the batch from FinalOut csv file
+    with tempfile.TemporaryDirectory() as temp_dirname:
+        # gets path of FinalOut csv file for current batch
+        cmd =  f"aws s3 ls --recursive {results_uri}/Results_{batch['batch_id']}_ | grep -e 'FinalOut'"
+        ps = subprocess.run(cmd, shell=True, 
+                            check=True, capture_output=True)
+        final_out_path_s3 = ps.stdout.decode().strip('\n').split(' ')[-1]
+        tmp_final_out = os.path.join(temp_dirname, "FinalOut.csv")
+        # downloads FinalOut csv file to temporary location
+        utils.s3_download_file(results_bucket, final_out_path_s3, tmp_final_out, endpoint_url=None)
+        # reads into a pandas dataframe
+        df_results = pd.read_csv(tmp_final_out, comment="#")
+    # queries s3 bucket for full results path
     cmd =  f"aws s3 ls {results_uri}/Results_{batch['batch_id']}_"
     ps = subprocess.run(cmd, shell=True, 
                         check=True, capture_output=True)
-    results_prefix = os.path.join(results_prefix, ps.stdout.decode().strip('\n').split(' ')[-1])
+    # joins the specific results path for current batch with the results prefix to produce a "complete" results prefix
+    results_prefix_complete = os.path.join(results_prefix, ps.stdout.decode().strip('\n').split(' ')[-1])
+    # add columns for reads and results URIs and sequence datetime
     df_results.insert(1, "results_bucket", "s3-csu-003")
-    df_results.insert(2, "results_prefix", results_prefix)#, results_path.split(os.path.sep)[-1]))
+    df_results.insert(2, "results_prefix", results_prefix_complete)#, results_path.split(os.path.sep)[-1]))
     df_results.insert(3, "sequenced_datetime", time.strftime("%d-%m-%y %H:%M:%S"))
     # join reads and results dataframes
     df_joined = df_reads.join(df_results.set_index('Sample'), on='sample_name', how='outer')
-    # if summary file already exists locally - append to existing file
-    if os.path.exists(summary_filepath):
-        df_summary = pd.read_csv(summary_filepath)
-        df_summary = pd.concat([df_summary, df_joined]).reset_index(drop=True)
-    # else create new
-    else:
-        df_summary = df_joined
-    df_summary.to_csv(summary_filepath, index=False)
+    return pd.concat([df_summary, df_joined]).reset_index(drop=True)
 
 def main(args):
     # Parse

--- a/utils.py
+++ b/utils.py
@@ -62,3 +62,15 @@ def upload_json(bucket, key, endpoint_url, dictionary, indent=4):
     obj = s3.Object(bucket, key)
 
     obj.put(Body=(bytes(json.dumps(dictionary, indent=indent).encode('UTF-8'))))
+
+def s3_download_file(bucket, key, dest, endpoint_url):
+    """
+        Downloads s3 folder at the key-bucket pair (strings) to dest 
+        path (string)
+    """
+    if s3_object_exists(bucket, key, endpoint_url):
+        s3 = boto3.client('s3')
+        s3.download_file(bucket, key, dest)
+    else:
+        raise Exception(f'{key} not found in {bucket}') 
+


### PR DESCRIPTION
This PR introduces a slightly different workflow for running the reprocess where nextflow's `-with-docker` option is utilised and the pipeline is run directly with files from s3. 

This has fixed some s3 path issues ensuring that the output of the pipeline is has the `run_id` embedded in the s3 uri. e.g. `s3://s3-csu-003/v3/SB4030/Results_NB501786_0379_15Jun22/`.

It requires `nextflow` to be installed and the user to be added to new "DOCKER" group. This is done in the install script `instal.bash`.

The general workflow (detailed in the readme) must be updated because a reboot is required in order to update the DOCKER group. 

I would like to also do a little bit more testing of this code before performing the reprocess. 