### PR TITLE
Clean test

### DIFF
--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -244,7 +244,7 @@ class BclEventHandler(FileSystemEventHandler):
                 bcl = os.path.join(self.watch_dir, plate)
                 backup = os.path.join(self.backup_dir, plate)
                 #remove_plate([fastq, bcl, backup])
-                remove_plate([fastq])
+                remove_plate([fastq, bcl])
 
     def on_created(self, event):
         """Called when a file or directory is created.

--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -216,6 +216,7 @@ class BclEventHandler(FileSystemEventHandler):
         # remove oldest plates until HD has required free space 
         self.clean_up()
 
+    #TODO: set return values or exceptions depending on outcome, e.g. if directories are emptied
     def clean_up(self, min_required_space=0.5):
         """
             Runs through all fully processed plates and deletes relevant data from

--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -232,6 +232,10 @@ class BclEventHandler(FileSystemEventHandler):
             HD. NOTE: this will only delete data if that plate has been fully processed.
 
             returns:
+                0:  if suffecient space on the filesystem is recovered
+            raises:
+                NoMoreDataError: if there is insuffecient space on the filesystem
+                and no more processed plates to delete 
         """
         # get list of processed plates sorted from oldest to youngest
         plates_by_time = sorted(os.listdir(self.fastq_dir), 

--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -148,7 +148,7 @@ def clean_up(directories):
             remove_old_plates(directory_path)
         # continue if directory_path is an empty folder
         except EmptyDirectoryError as _:
-            pass
+            pass    
 
 def remove_old_plates(directory_path):
     """

--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -221,6 +221,7 @@ class BclEventHandler(FileSystemEventHandler):
         # remove oldest plates until HD has required free space 
         try:
             self.clean_up()
+        # don't crash if there is no more data to delete but log the exception
         except NoMoreDataError as e:
             logging.exception(e)
 
@@ -242,7 +243,7 @@ class BclEventHandler(FileSystemEventHandler):
             oldest_bcl = os.path.join(self.watch_dir, plate)
             oldest_backup = os.path.join(self.backup_dir, plate)
             # get free space on filesystem
-            total, free = monitor_disk_usage(oldest_fastq)
+            total, free = monitor_disk_usage(self.fastq_dir)
             if free / total < min_required_space:
                 # remove oldest data from the 3 data directories
                 remove_plate([oldest_fastq, oldest_bcl, oldest_backup])
@@ -251,7 +252,7 @@ class BclEventHandler(FileSystemEventHandler):
                 return 0
         # raise exception if there is insuffecient space on the HD and 
         # no processed plates to delete  
-        total, free = monitor_disk_usage(oldest_fastq)
+        total, free = monitor_disk_usage(self.fastq_dir)
         if free / total < min_required_space:
             raise NoMoreDataError()
         else:

--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -27,6 +27,10 @@ bcl_manager.py is a file-watcher that runs on wey-001 for automated:
 """
 
 class NoMoreDataError(Exception):
+    """
+        This exception is raised if there is no processed data left to delete and
+        there is insuffecient space left on HD 
+    """
     def __init__(self):
         self.message =  "All processed plates deleted but there is still insuffecient \
                          space on the filesystem: consider manually deleting redundant files"

--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -1,5 +1,3 @@
-import sys
-import time
 import logging
 import ntpath
 import argparse
@@ -13,7 +11,7 @@ import glob
 from datetime import datetime
 
 from watchdog.observers import Observer
-from watchdog.events import LoggingEventHandler, FileCreatedEvent, FileSystemEventHandler
+from watchdog.events import FileSystemEventHandler
 
 from s3_logging_handler import S3LoggingHandler
 
@@ -154,7 +152,7 @@ def remove_old_plates(directory_path, min_required_space=0.5):
     """
         Removes oldest files within 'directory_path' (str) until filesystem the 
         filepath is mounted on has more than 'min_required_space' available free 
-        space as a fraction of total filesystem capacity.
+        space, as a fraction of total filesystem capacity.
 
         params:
             directory_path (string): path to directory from which to delete data
@@ -177,7 +175,7 @@ def remove_old_plates(directory_path, min_required_space=0.5):
             try:
                 shutil.rmtree(os.path.join(directory_path, oldest))
                 logging.info(f"Removing old data: '{oldest}'")
-            except NotADirectoryError as e:
+            except NotADirectoryError as _:
                 logging.info(f"Not deleting '{oldest}' as filepath does not match plate format")
         # if > 50% free space: break and return 
         else:

--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -243,7 +243,8 @@ class BclEventHandler(FileSystemEventHandler):
                 fastq = os.path.join(self.fastq_dir, plate)
                 bcl = os.path.join(self.watch_dir, plate)
                 backup = os.path.join(self.backup_dir, plate)
-                remove_plate([fastq, bcl, backup])
+                #remove_plate([fastq, bcl, backup])
+                remove_plate([fastq])
 
     def on_created(self, event):
         """Called when a file or directory is created.

--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -167,7 +167,10 @@ def remove_old_plates(directory_path):
             oldest = min(os.listdir(directory_path), 
                          key=lambda p: os.path.getctime(os.path.join(directory_path, p)))
             # delete oldest object
-            shutil.rmtree(os.path.join(directory_path, oldest))
+            try:
+                shutil.rmtree(os.path.join(directory_path, oldest))
+            except NotADirectoryError as e:
+                logging.info(f"Not deleting '{oldest}' as filepath does not match plate format")
         # if > 50% free space: break and return 
         else:
             break

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 watchdog
+pyfakefs
 boto3

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -5,8 +5,8 @@ import os
 import tempfile
 
 from pyfakefs import fake_filesystem_unittest
-
 import watchdog
+
 import bcl_manager
 from bcl_manager import SubdirectoryException
 
@@ -16,8 +16,7 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
             Set up method
         """
         # use "fake" in-memory filesystem
-        pass
-        #self.setUpPyfakefs()
+        self.setUpPyfakefs()
 
     def tearDown(self):
         """

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -1,6 +1,6 @@
 import unittest
 import unittest.mock
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock, MagicMock, patch
 
 import watchdog
 import bcl_manager
@@ -137,6 +137,13 @@ class TestBclManager(unittest.TestCase):
         # Raises error if src_path is incorrectly formatted
         with self.assertRaises(Exception):
             bcl_manager.upload(bad_src_path, '', '', '')
+
+    def test_remove_old_plates(self):
+        with patch("bcl_manager.monitor_disk_usage") as mock_monitor_disk_usage:
+            mock_monitor_disk_usage.side_effect = [(100, 0), (100, 20), (100, 40), (100, 60), (100, 80), (100, 100)]
+            # make a tempdir with some folders inside created sequentially
+            # call bcl_manager.remove_old_plates() and ensure that shutil.remtree was called the correct number of times
+            # should perhaps consider mocking out all the IO functions - don't know.
 
 if __name__ == '__main__':
     unittest.main()

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -185,7 +185,8 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
         # expected calls to bcl_manager.shutil.rmtree
         rmtree_calls = [unittest.mock.call(os.path.join(temp_filesystem, "plate_1")),
                         unittest.mock.call(os.path.join(temp_filesystem, "plate_2")),
-                        unittest.mock.call(os.path.join(temp_filesystem, "plate_3"))]
+                        unittest.mock.call(os.path.join(temp_filesystem, "plate_3")),
+                        unittest.mock.call(os.path.join(temp_filesystem, "plate_4"))]
         # assert bcl_manager.shutil.rmtreee has expected calls
         bcl_manager.shutil.rmtree.assert_has_calls(rmtree_calls)
 

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -156,6 +156,7 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
         with self.assertRaises(Exception):
             bcl_manager.upload(bad_src_path, '', '', '')
 
+    # TODO: change to test_clean_up - and mock remove_plate() function
     @patch("bcl_manager.monitor_disk_usage")
     def test_remove_old_plates(self, mock_monitor_disk_usage):
         """

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -13,10 +13,16 @@ from bcl_manager import SubdirectoryException
 
 class TestBclManager(fake_filesystem_unittest.TestCase):
     def setUp(self):
-        #self.setUpPyfakefs()
-        pass
+        """
+            Set up method
+        """
+        # use "fake" in-memory filesystem
+        self.setUpPyfakefs()
 
     def tearDown(self):
+        """
+            Tear down method
+        """
         pass
 
     def test_handler_construction(self):
@@ -152,37 +158,30 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
 
     @patch("bcl_manager.monitor_disk_usage")
     def test_remove_old_plates(self, mock_monitor_disk_usage):
+        """
+            Test removing old plates
+        """
+        # mock bcl_manager.shutil.rmtree - but retain functionality
         bcl_manager.shutil.rmtree = Mock(wraps=shutil.rmtree)
+        # mock bcl_manager.monitor_disk_usage with side effects
         mock_monitor_disk_usage.side_effect = [(100, 0), (100, 20), (100, 40), (100, 60), (100, 80), (100, 100)]
+        # use a temporary directory as a mock filesystem
         with tempfile.TemporaryDirectory() as temp_filesystem:
-            os.mkdir(os.path.join(temp_filesystem, "a"))
-            os.mkdir(os.path.join(temp_filesystem, "b"))
-            os.mkdir(os.path.join(temp_filesystem, "c"))
-            os.mkdir(os.path.join(temp_filesystem, "d"))
-            os.mkdir(os.path.join(temp_filesystem, "e"))
-            os.mkdir(os.path.join(temp_filesystem, "f"))
-            #with open(os.path.join(temp_filesystem, "a"), "w") as _:
-                #pass
-            #with open(os.path.join(temp_filesystem, "b"), "w") as _:
-                #pass
-            #with open(os.path.join(temp_filesystem, "c"), "w") as _:
-                #pass
-            #with open(os.path.join(temp_filesystem, "d"), "w") as _:
-                #pass
-            #with open(os.path.join(temp_filesystem, "e"), "w") as _:
-                #pass
-            #with open(os.path.join(temp_filesystem, "f"), "w") as _:
-                #pass
+            # make directories sequentially - mock plates
+            os.mkdir(os.path.join(temp_filesystem, "plate_1"))
+            os.mkdir(os.path.join(temp_filesystem, "plate_2"))
+            os.mkdir(os.path.join(temp_filesystem, "plate_3"))
+            os.mkdir(os.path.join(temp_filesystem, "plate_4"))
+            os.mkdir(os.path.join(temp_filesystem, "plate_5"))
+            os.mkdir(os.path.join(temp_filesystem, "plate_6"))
+            # remove old plates
             bcl_manager.remove_old_plates(temp_filesystem)
-        calls = [unittest.mock.call(os.path.join(temp_filesystem, "a")),
-                 unittest.mock.call(os.path.join(temp_filesystem, "b")),
-                 unittest.mock.call(os.path.join(temp_filesystem, "c"))]
-        bcl_manager.shutil.rmtree.assert_has_calls(calls)
-
-
-
-            # call bcl_manager.remove_old_plates() and ensure that shutil.rmtree was called the correct number of times
-            # should perhaps consider mocking out all the IO functions - don't know.
+        # expected calls to bcl_manager.shutil.rmtree
+        rmtree_calls = [unittest.mock.call(os.path.join(temp_filesystem, "plate_1")),
+                        unittest.mock.call(os.path.join(temp_filesystem, "plate_2")),
+                        unittest.mock.call(os.path.join(temp_filesystem, "plate_3"))]
+        # assert bcl_manager.shutil.rmtreee has expected calls
+        bcl_manager.shutil.rmtree.assert_has_calls(rmtree_calls)
 
 if __name__ == '__main__':
     unittest.main()

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -1,6 +1,7 @@
 import unittest
 import unittest.mock
 from unittest.mock import Mock, MagicMock, patch
+import time
 import os
 import tempfile
 import shutil
@@ -167,12 +168,17 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
         mock_monitor_disk_usage.side_effect = [(100, 0), (100, 20), (100, 40), (100, 60), (100, 80), (100, 100)]
         # use a temporary directory as a mock filesystem
         with tempfile.TemporaryDirectory() as temp_filesystem:
-            # make directories sequentially - mock plates
+            # make directories sequentially (mock plates)
             os.mkdir(os.path.join(temp_filesystem, "plate_1"))
+            time.sleep(0.1)
             os.mkdir(os.path.join(temp_filesystem, "plate_2"))
+            time.sleep(0.1)
             os.mkdir(os.path.join(temp_filesystem, "plate_3"))
+            time.sleep(0.1)
             os.mkdir(os.path.join(temp_filesystem, "plate_4"))
+            time.sleep(0.1)
             os.mkdir(os.path.join(temp_filesystem, "plate_5"))
+            time.sleep(0.1)
             os.mkdir(os.path.join(temp_filesystem, "plate_6"))
             # remove old plates
             bcl_manager.remove_old_plates(temp_filesystem)

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -185,8 +185,7 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
         # expected calls to bcl_manager.shutil.rmtree
         rmtree_calls = [unittest.mock.call(os.path.join(temp_filesystem, "plate_1")),
                         unittest.mock.call(os.path.join(temp_filesystem, "plate_2")),
-                        unittest.mock.call(os.path.join(temp_filesystem, "plate_3")),
-                        unittest.mock.call(os.path.join(temp_filesystem, "plate_4"))]
+                        unittest.mock.call(os.path.join(temp_filesystem, "plate_3"))]
         # assert bcl_manager.shutil.rmtreee has expected calls
         bcl_manager.shutil.rmtree.assert_has_calls(rmtree_calls)
 

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -203,11 +203,12 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
                                               os.path.join(temp_directory, "watch_dir/plate_2"), 
                                               os.path.join(temp_directory, "backup_dir/plate_2")])
 
+        # TODO: test emptying directory - the test is that it works without raising exceptions atm - but perhaps can be signalled by a return value from clean_up() method 
         # mock bcl_manager.monitor_disk_usage with side-effects (increasing space)
         with patch("bcl_manager.monitor_disk_usage") as mock_monitor_disk_usage:
             mock_monitor_disk_usage.side_effect = [(100, 0), 
                                                    (100, 40), 
-                                                   (100, 60)] 
+                                                   (100, 45)] 
             # use a temporary directory as a 'sandbox'
             with tempfile.TemporaryDirectory() as temp_directory:
                 # 'mock-up' plates - raw bcl data
@@ -234,13 +235,17 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
                 # remove old plates
                 handler.clean_up()
         # assert bcl_manager.remove_plate first call
+        # TODO: make ordered
         bcl_manager.remove_plate.assert_any_call([os.path.join(temp_directory, "fastq_dir/plate_1"), 
                                            os.path.join(temp_directory, "watch_dir/plate_1"), 
                                            os.path.join(temp_directory, "backup_dir/plate_1")])
+        bcl_manager.remove_plate.assert_any_call([os.path.join(temp_directory, "fastq_dir/plate_2"), 
+                                           os.path.join(temp_directory, "watch_dir/plate_2"), 
+                                           os.path.join(temp_directory, "backup_dir/plate_2")])
         # assert bcl_manager.remove_plate last call
-        bcl_manager.remove_plate.assert_called_with([os.path.join(temp_directory, "fastq_dir/plate_2"), 
-                                              os.path.join(temp_directory, "watch_dir/plate_2"), 
-                                              os.path.join(temp_directory, "backup_dir/plate_2")])
+        bcl_manager.remove_plate.assert_called_with([os.path.join(temp_directory, "fastq_dir/plate_3"), 
+                                              os.path.join(temp_directory, "watch_dir/plate_3"), 
+                                              os.path.join(temp_directory, "backup_dir/plate_3")])
 
        # # test fully clearning directory
        # # mock bcl_manager.monitor_disk_usage with side-effects (increasing space)

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -213,9 +213,11 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
                 # call clean_up
                 handler.clean_up()
         # assert bcl_manager.remove_plate first call
-        bcl_manager.remove_plate.assert_any_call([os.path.join(temp_directory, "fastq_dir/plate_1")]) 
+        bcl_manager.remove_plate.assert_any_call([os.path.join(temp_directory, "fastq_dir/plate_1"), 
+                                                  os.path.join(temp_directory, "watch_dir/plate_1")])
         # assert bcl_manager.remove_plate last call
-        bcl_manager.remove_plate.assert_called_with([os.path.join(temp_directory, "fastq_dir/plate_2")]) 
+        bcl_manager.remove_plate.assert_called_with([os.path.join(temp_directory, "fastq_dir/plate_2"), 
+                                                     os.path.join(temp_directory, "watch_dir/plate_2")])
         # reset call attributes of bcl_manager.remove_plate mock
         bcl_manager.remove_plate.reset_mock()
 

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -196,7 +196,7 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
                                                       '', 
                                                       '')
                 # remove old plates - assert normal return
-                self.assertEqual(handler.clean_up(), 0)
+                self.assertEqual(handler.clean_up(0.5), 0)
         # assert bcl_manager.remove_plate first call
         bcl_manager.remove_plate.assert_any_call([os.path.join(temp_directory, "fastq_dir/plate_1"), 
                                                   os.path.join(temp_directory, "watch_dir/plate_1"), 
@@ -233,7 +233,7 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
                                                       '', 
                                                       '')
                 # remove old plates - assert normal return
-                self.assertEqual(handler.clean_up(), 0)
+                self.assertEqual(handler.clean_up(0.5), 0)
         # assert bcl_manager.remove_plate called only once with plate_1
         bcl_manager.remove_plate.assert_called_once_with([os.path.join(temp_directory, "fastq_dir/plate_1"), 
                                                           os.path.join(temp_directory, "watch_dir/plate_1"), 
@@ -265,7 +265,7 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
                                                       '')
                 # remove old plates - assert NoMoreDataError
                 with self.assertRaises(bcl_manager.NoMoreDataError):
-                    self.assertRaises(handler.clean_up())
+                    self.assertRaises(handler.clean_up(0.5))
         # reset call attributes of bcl_manager.remove_plate mock
         bcl_manager.remove_plate.reset_mock()
 
@@ -290,7 +290,7 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
                                                       '', 
                                                       '')
                 # remove old plates - assert normal return
-                self.assertEqual(handler.clean_up(), 0)
+                self.assertEqual(handler.clean_up(0.5), 0)
                 # assert bcl_manager.remove_plate() is never called
                 bcl_manager.remove_plate.assert_not_called()
 

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -156,7 +156,7 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
         with self.assertRaises(Exception):
             bcl_manager.upload(bad_src_path, '', '', '')
 
-    def test_remove_old_plates(self):#, mock_remove_plate):
+    def test_clean_up(self):#, mock_remove_plate):
         """
             Test removing old plates
         """
@@ -213,13 +213,9 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
                 # call clean_up
                 handler.clean_up()
         # assert bcl_manager.remove_plate first call
-        bcl_manager.remove_plate.assert_any_call([os.path.join(temp_directory, "fastq_dir/plate_1"), 
-                                                  os.path.join(temp_directory, "watch_dir/plate_1"), 
-                                                  os.path.join(temp_directory, "backup_dir/plate_1")])
+        bcl_manager.remove_plate.assert_any_call([os.path.join(temp_directory, "fastq_dir/plate_1")]) 
         # assert bcl_manager.remove_plate last call
-        bcl_manager.remove_plate.assert_called_with([os.path.join(temp_directory, "fastq_dir/plate_2"), 
-                                                     os.path.join(temp_directory, "watch_dir/plate_2"), 
-                                                     os.path.join(temp_directory, "backup_dir/plate_2")])
+        bcl_manager.remove_plate.assert_called_with([os.path.join(temp_directory, "fastq_dir/plate_2")]) 
         # reset call attributes of bcl_manager.remove_plate mock
         bcl_manager.remove_plate.reset_mock()
 

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -234,43 +234,16 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
                                                       '')
                 # remove old plates
                 handler.clean_up()
-        # assert bcl_manager.remove_plate first call
-        # TODO: make ordered
-        bcl_manager.remove_plate.assert_any_call([os.path.join(temp_directory, "fastq_dir/plate_1"), 
-                                           os.path.join(temp_directory, "watch_dir/plate_1"), 
-                                           os.path.join(temp_directory, "backup_dir/plate_1")])
-        bcl_manager.remove_plate.assert_any_call([os.path.join(temp_directory, "fastq_dir/plate_2"), 
-                                           os.path.join(temp_directory, "watch_dir/plate_2"), 
-                                           os.path.join(temp_directory, "backup_dir/plate_2")])
-        # assert bcl_manager.remove_plate last call
+        remove_plate_calls = [unittest.mock.call([os.path.join(temp_directory, "fastq_dir/plate_1"), 
+                                                  os.path.join(temp_directory, "watch_dir/plate_1"), 
+                                                  os.path.join(temp_directory, "backup_dir/plate_1")]),
+                              unittest.mock.call([os.path.join(temp_directory, "fastq_dir/plate_2"), 
+                                                  os.path.join(temp_directory, "watch_dir/plate_2"), 
+                                                  os.path.join(temp_directory, "backup_dir/plate_2")])]
+        bcl_manager.remove_plate.assert_has_calls(remove_plate_calls)
         bcl_manager.remove_plate.assert_called_with([os.path.join(temp_directory, "fastq_dir/plate_3"), 
                                               os.path.join(temp_directory, "watch_dir/plate_3"), 
                                               os.path.join(temp_directory, "backup_dir/plate_3")])
-
-       # # test fully clearning directory
-       # # mock bcl_manager.monitor_disk_usage with side-effects (increasing space)
-       # with patch("bcl_manager.monitor_disk_usage") as mock_monitor_disk_usage:
-       #     mock_monitor_disk_usage.side_effect = [(100, 0), 
-       #                                            (100, 20), 
-       #                                            (100, 40), 
-       #                                            (100, 60), 
-       #                                            (100, 80), 
-       #                                            (100, 100)]
-       #     # use a temporary directory as a 'sandbox'
-       #     with tempfile.TemporaryDirectory() as temp_directory:
-       #         # make directories sequentially (mock plates) 
-       #         # 2 plates only: directory empties before filesystem has > 50% free space
-       #         os.makedirs(os.path.join(temp_directory, "plate_1"))
-       #         time.sleep(0.1)
-       #         os.makedirs(os.path.join(temp_directory, "plate_2"))
-       #         # assert that temp_direcotry is emptied abd the exception is raised
-       #         with self.assertRaises(bcl_manager.EmptyDirectoryError):
-       #             bcl_manager.remove_old_plates(temp_directory)
-       # # expected calls to bcl_manager.shutil.rmtree
-       # rmtree_calls = [unittest.mock.call(os.path.join(temp_directory, "plate_1")),
-       #                 unittest.mock.call(os.path.join(temp_directory, "plate_2"))]
-       # # assert bcl_manager.shutil.rmtreee has expected calls
-       # bcl_manager.shutil.rmtree.assert_has_calls(rmtree_calls)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR is very similar to https://github.com/APHA-CSU/sequence-manager/pull/28#issue-1382586225, except that it will not delete BCL data and its backup files.

I have created this PR with the intention that it's code will be initially deployed to `wey-001` and left for a period of time to ensure that it is working as designed (to remove fastq data that is older than 30 days), before merging in https://github.com/APHA-CSU/sequence-manager/pull/28#issue-1382586225 and deploying this to `wey-001`.

I think this is sensible because we can make sure that the algorithm for removing old data is working as designed in production before using it to delete critical BCL data that we cannot easily re-generate. 