### PR TITLE
Clean bug fix

### DIFF
--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -234,7 +234,8 @@ class BclEventHandler(FileSystemEventHandler):
         for plate in os.listdir(self.fastq_dir):
             # dattime of fastq processing for each plate
             modified_date = \
-                datetime.fromtimestamp(os.path.getmtime(plate))
+                    datetime.fromtimestamp(os.path.getmtime(\
+                    os.path.join(self.fastq_dir, plate)))
             # age of the processed plate
             age = today - modified_date
             # delete processed, raw and backup files if processed plate is older

--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -26,18 +26,6 @@ bcl_manager.py is a file-watcher that runs on wey-001 for automated:
 
 """
 
-class NoMoreDataError(Exception):
-    """
-        This exception is raised if there is no processed data left to delete and
-        there is insuffecient space left on HD 
-    """
-    def __init__(self):
-        self.message =  "All processed plates deleted but there is still insuffecient \
-                         space on the filesystem: consider manually deleting redundant files"
-    
-    def __str__(self):
-        return self.message
-
 
 def convert_to_fastq(src_dir, dest_dir):
     """
@@ -142,14 +130,14 @@ def remove_plate(plate_paths):
         Deletes the directory tree at the paths in each element of 
         'plate_paths' (list)
     """
-    for path in plate_paths:
-        try:
+    try:
+        for path in plate_paths:
             shutil.rmtree(path)
             logging.info(f"Removing old data: '{path}'")
-        except NotADirectoryError as _:
-            logging.info(f"Not deleting '{path}' as filepath does not match \
-                plate format")
-    
+    except NotADirectoryError as _:
+        logging.info(f"Not deleting '{path}' as filepath does not match "     
+            "plate format")
+
 
 class BclEventHandler(FileSystemEventHandler):
     """
@@ -239,7 +227,7 @@ class BclEventHandler(FileSystemEventHandler):
             # age of the processed plate
             age = today - modified_date
             # delete processed, raw and backup files if processed plate is older
-            # 30 days
+            # than 30 days
             if age.days > 30:
                 fastq = os.path.join(self.fastq_dir, plate)
                 bcl = os.path.join(self.watch_dir, plate)

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, MagicMock, patch, call
 import time
 import os
 import tempfile
+import pathlib
 
 from pyfakefs import fake_filesystem_unittest
 import watchdog
@@ -12,18 +13,18 @@ from bcl_manager import SubdirectoryException
 
 
 class TestBclManager(fake_filesystem_unittest.TestCase):
-    def setUp(self):
-        """
-            Set up method
-        """
-        # use "fake" in-memory filesystem
-        self.setUpPyfakefs()
+    #def setUp(self):
+        #"""
+            #Set up method
+        #"""
+        ## use "fake" in-memory filesystem
+        #self.setUpPyfakefs()
 
-    def tearDown(self):
-        """
-            Tear down method
-        """
-        pass
+    #def tearDown(self):
+        #"""
+            #Tear down method
+        #"""
+        #pass
 
     def test_handler_construction(self):
         # Succeeds when output directories exist
@@ -167,69 +168,69 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
         # Test removing 2 fully processed plates and leaving the 3rd as it is <
         # 30 days old
 
-        # mock bcl_manager.monitor_disk_usage with side-effects (increasing space)
         with patch("bcl_manager.os.path.getmtime") as mock_getmtime:
-            def mock_getmtime_returns(dirname):
-                """
-                    Inner function for return value of mocked 
-                    os.path.getmtime(). The return value (age of the dir) is
-                    dependent on the argument name of the directory. Return
-                    values simulate directories of ages 32, 31 and 29 days.
-                """
-                # assert that bcl_manager.os.path.getmtime() is called on 
-                # existing path
-                self.assertTrue(os.path.exists(dirname))
-                now = time.time()
-                plate_name = os.path.basename(dirname)
-                if plate_name == "plate_1":
-                    return now - 2851200
-                elif plate_name == "plate_2":
-                    return now - 2764801
-                elif plate_name == "plate_3":
-                    return now - 2505601
-                else:
-                    raise Exception("not a valid mock plate name")
-            # side effects: current time less 32 days; 31 days; 29 days (in 
-            # seconds), i.e. simulating plates of 32, 31 and 29 days old
-            mock_getmtime.side_effect = lambda x: mock_getmtime_returns(x)
-            # use a temporary directory as a 'sandbox'
-            with tempfile.TemporaryDirectory() as temp_directory:
-                # 'mock-up' plates - raw bcl data
-                os.makedirs(os.path.join(temp_directory, "watch_dir/plate_1"))
-                os.makedirs(os.path.join(temp_directory, "watch_dir/plate_2"))
-                os.makedirs(os.path.join(temp_directory, "watch_dir/plate_3"))
-                # 'mock-up' plates - backup bcl data
-                os.makedirs(os.path.join(temp_directory, "backup_dir/plate_1"))
-                os.makedirs(os.path.join(temp_directory, "backup_dir/plate_2"))
-                os.makedirs(os.path.join(temp_directory, "backup_dir/plate_3"))
-                # 'mock-up' plates - processed data
-                os.makedirs(os.path.join(temp_directory, "fastq_dir/plate_1"))
-                os.makedirs(os.path.join(temp_directory, "fastq_dir/plate_2"))
-                os.makedirs(os.path.join(temp_directory, "fastq_dir/plate_3"))
-                # Test handler
-                handler = bcl_manager.BclEventHandler(os.path.join(temp_directory, "watch_dir"),
-                                                      os.path.join(temp_directory, "backup_dir"),
-                                                      os.path.join(temp_directory, "fastq_dir"),
-                                                      '', 
-                                                      '', 
-                                                      '')
-                # call clean_up
-                handler.clean_up()
+           def mock_getmtime_returns(dirname):
+              """
+                 #Inner function for return value of mocked 
+                 #os.path.getmtime(). The return value (age of the dir) is
+                 #dependent on the argument name of the directory. Return
+                 #values simulate directories of ages 32, 31 and 29 days.
+              """
+              # assert that bcl_manager.os.path.getmtime() is called on 
+              # existing path
+              self.assertTrue(os.path.exists(dirname))
+              now = time.time()
+              plate_name = os.path.basename(dirname)
+              if plate_name == "plate_1":
+                 return now - 2851200
+              elif plate_name == "plate_2":
+                 return now - 2764801
+              elif plate_name == "plate_3":
+                 return now - 2505601
+              else:
+                 raise Exception("not a valid mock plate name")
+           # side effects: current time less 32 days; 31 days; 29 days (in 
+           # sconds), i.e. simulating plates of 32, 31 and 29 days old
+           mock_getmtime.side_effect = lambda x: mock_getmtime_returns(x)
+           # use a temporary directory as a 'sandbox'
+           with tempfile.TemporaryDirectory() as temp_directory:
+              # 'mock-up' plates - raw bcl data
+              os.makedirs(os.path.join(temp_directory, "watch_dir/plate_1"))
+              os.makedirs(os.path.join(temp_directory, "watch_dir/plate_2"))
+              os.makedirs(os.path.join(temp_directory, "watch_dir/plate_3"))
+              # 'mock-up' plates - backup bcl data
+              os.makedirs(os.path.join(temp_directory, "backup_dir/plate_1"))
+              os.makedirs(os.path.join(temp_directory, "backup_dir/plate_2"))
+              os.makedirs(os.path.join(temp_directory, "backup_dir/plate_3"))
+              # 'mock-up' plates - processed data
+              os.makedirs(os.path.join(temp_directory, "fastq_dir/plate_1"))
+              os.makedirs(os.path.join(temp_directory, "fastq_dir/plate_2"))
+              os.makedirs(os.path.join(temp_directory, "fastq_dir/plate_3"))
+              # Test handler
+              handler = bcl_manager.BclEventHandler(os.path.join(temp_directory, "watch_dir"),
+                                                    os.path.join(temp_directory, "backup_dir"),
+                                                    os.path.join(temp_directory, "fastq_dir"),
+                                                    '', 
+                                                    '', 
+                                                    '')
+              # call clean_up
+              handler.clean_up()
         correct_calls = [call([os.path.join(temp_directory, "fastq_dir/plate_1"), os.path.join(temp_directory, "watch_dir/plate_1")]),
                          call([os.path.join(temp_directory, "fastq_dir/plate_2"), os.path.join(temp_directory, "watch_dir/plate_2")])]
         # assert correct calls regardless of order
         self.assertCountEqual(correct_calls, bcl_manager.remove_plate.mock_calls)
         # reset call attributes of bcl_manager.remove_plate mock
         bcl_manager.remove_plate.reset_mock()
+        # reset call attributes of bcl_manager.os.path.getmtime mock
+        bcl_manager.os.path.getmtime.reset_mock()
 
         # Test removing no plates
 
-        # mock bcl_manager.monitor_disk_usage with side-effects (increasing space)
         with patch("bcl_manager.os.path.getmtime") as mock_getmtime:
             now = time.time()
             # side effects: current time less 29 daysin 
             # seconds), i.e. simulating plates of 32, 31 and 29 days old
-            mock_getmtime.side_effect = now - 2505601
+            mock_getmtime.return_value = now - 2505601
             # use a temporary directory as a 'sandbox'
             with tempfile.TemporaryDirectory() as temp_directory:
                 # 'mock-up' plates - raw bcl data
@@ -251,8 +252,46 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
                                                       '', 
                                                       '', 
                                                       '')
+                # call clean_up
+                handler.clean_up()
         # assert bcl_manager.remove_plate 
         assert not bcl_manager.remove_plate.called
+        # reset call attributes of bcl_manager.remove_plate mock
+        bcl_manager.remove_plate.reset_mock()
+        # reset call attributes of bcl_manager.os.path.getmtime mock
+        bcl_manager.os.path.getmtime.reset_mock()
 
+        # Test skipping files (files in the plate directories, i.e. that don't
+        # fit the plate format)
+
+        with patch("bcl_manager.os.path.getmtime") as mock_getmtime:
+            now = time.time()
+            # side effects: current time less 29 daysin 
+            # seconds), i.e. simulating plates of 32, 31 and 29 days old
+            mock_getmtime.return_value = now - 2851200
+            # mock bcl_manager.shutil.rmtree but retain functionality
+            bcl_manager.shutil.rmtree = Mock(wraps=bcl_manager.shutil.rmtree)
+            # use a temporary directory as a 'sandbox'
+            with tempfile.TemporaryDirectory() as temp_directory:
+                os.makedirs(os.path.join(temp_directory, "watch_dir"))
+                os.makedirs(os.path.join(temp_directory, "backup_dir"))
+                os.makedirs(os.path.join(temp_directory, "fastq_dir"))
+                # 'mock-up' a file in processed data dir
+                pathlib.Path(os.path.join(temp_directory, "fastq_dir/plate_1")).touch()
+                # Test handler
+                handler = bcl_manager.BclEventHandler(os.path.join(temp_directory, "watch_dir"), 
+                                                      os.path.join(temp_directory, "backup_dir"), 
+                                                      os.path.join(temp_directory, "fastq_dir"),
+                                                      '', 
+                                                      '', 
+                                                      '')
+                # call clean_up
+                handler.clean_up()
+        # assert NotADirectoryError is raised
+        self.assertRaises(NotADirectoryError)
+        # assert bcl_manager.shutil.rmtree() is called only once with 
+        # 'fastq_dir/plate_1' filepath, i.e. skips looking for non-existing file
+        # backup and watch dirs
+        bcl_manager.shutil.rmtree.assert_called_once_with(os.path.join(temp_directory, "fastq_dir/plate_1"))
 if __name__ == '__main__':
     unittest.main()

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -13,18 +13,18 @@ from bcl_manager import SubdirectoryException
 
 
 class TestBclManager(fake_filesystem_unittest.TestCase):
-    #def setUp(self):
-        #"""
-            #Set up method
-        #"""
-        ## use "fake" in-memory filesystem
-        #self.setUpPyfakefs()
+    def setUp(self):
+       """
+          #Set up method
+       """
+       # use "fake" in-memory filesystem
+       self.setUpPyfakefs()
 
-    #def tearDown(self):
-        #"""
-            #Tear down method
-        #"""
-        #pass
+    def tearDown(self):
+       """
+          #Tear down method
+       """
+       pass
 
     def test_handler_construction(self):
         # Succeeds when output directories exist


### PR DESCRIPTION
This PR fixes a bug which was causing `bcl_manager` to crash:

```
2022-12-08 19:20:46 - [Errno 2] No such file or directory: '221125_NB501786_0463_AHW7W3AFX3'
Traceback (most recent call last):
  File "bcl_manager.py", line 267, in on_created
    self.process_bcl_plate(event.src_path)
  File "bcl_manager.py", line 224, in process_bcl_plate
    self.clean_up()
  File "bcl_manager.py", line 237, in clean_up
    datetime.fromtimestamp(os.path.getmtime(plate))
  File "/usr/lib/python3.8/genericpath.py", line 55, in getmtime
    return os.stat(filename).st_mtime
FileNotFoundError: [Errno 2] No such file or directory: '221125_NB501786_0463_AHW7W3AFX3'
```

This was due to passing just the "basename" of the filepath for a fastq output directory to `os.path.getmtime()` on line 277 of `bcl_manager.py`. This has been fixed by including the full path.

Unfortunately, the bug was not picked up in unit tests because `os.path.getmtime()` was mocked out, for `mock_getmtime_returns()`. To ensure that this potential bug is tested for I have included an assertion that the argument to `mock_getmtime_returns()` is a valid existing filepath: line 181 in `unit_tests.py`.

I have also ensured that the order of calls to `bcl_manager.remove_plate()` does not matter.