### PR TITLE
Remove backup rather than original bcl folder

### DIFF
--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -234,10 +234,10 @@ class BclEventHandler(FileSystemEventHandler):
                     # delete processed, raw and backup files if processed plate 
                     # is older than 30 days
                     if age.days > 30:
-                        bcl_plate = os.path.join(self.watch_dir, plate)
-                        #backup_plate = os.path.join(self.backup_dir, plate)
+                        #bcl_plate = os.path.join(self.watch_dir, plate)
+                        backup_plate = os.path.join(self.backup_dir, plate)
                         #remove_plate([fastq_plate, bcl_plate, backup_plate])
-                        remove_plate([fastq_plate, bcl_plate])
+                        remove_plate([fastq_plate, backup_plate])
             except NotADirectoryError:
                 pass
 


### PR DESCRIPTION
This PR fixes an issue where `clean_up` was trying to remove the folder from the `IncomingRuns` directory.  However, this disc space is smaller and often cleaned up before the 30 day cutoff.  The process now removes the backup bcl directory.

It may make sense to remove the original bcl directory from `IncomingRuns` (watch_dir) as soon as `bcl-convert` completes successfully.  The backup will still be kept for 30 days and can be used where there are issues.