### PR TITLE
log watch_dir rather than deleted CopyComplete.txt

### DIFF
--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -273,7 +273,7 @@ class BclEventHandler(FileSystemEventHandler):
 
         # Log remaining disk space
         logging.info('New Illumina Plate Processed: %s' % event.src_path)
-        log_disk_usage(event.src_path)
+        log_disk_usage(self.watch_dir)
         log_disk_usage(self.fastq_dir)
         log_disk_usage(self.backup_dir)  
 


### PR DESCRIPTION
This PR fixes a bug which was causing `bcl_manager` to crash.

The issue was that `log_disk_usage()` was logging disk usage on `event.src_path` which happens to be `Illumina/IncomingRuns/<plate>/CopyComplete.txt`, where plate corresponds to the recently processed plate, which has just been cleaned up, so `CopyComplete.txt` doesn't exist.

Simply changing to `self.watchdir()` should fix this problem. 