### PR TITLE
Salmonella scebatch

### DIFF
--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -194,7 +194,7 @@ class BclEventHandler(FileSystemEventHandler):
         logging.info(f'Converting to fastq: {event.fastq_path}')
         convert_to_fastq(event.abs_src_path, event.fastq_path)
 
-        # Upload to SCE and run Salmonella pipeline
+        # upload to SCE and run Salmonella pipeline
         self.upload(event)
 
         # remove all plates where the processed data is older than 30
@@ -259,6 +259,8 @@ class BclEventHandler(FileSystemEventHandler):
                                "sequence_date": str(sequence_date.date()),
                                "upload_time": str(datetime.now())})
             utils.s3_sync(dirname, self.fastq_bucket, key, self.s3_endpoint_url)
+            if project_code in SALMONELLA_PROJECT_CODES:
+                submit_batch_job(project_code, key)
 
     def on_created(self, event):
         """Called when a file or directory is created.

--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -146,14 +146,13 @@ def submit_batch_job(reads_bucket, reads_key, results_bucket, name,
             name (str): the s3 key to store the results under
             submission_bucket (str): the s3 bucket for receiving aws
                                      batch job submissions
-            s3_endpoint_url (str): the s3 endpoint url for the
-                                   submission bucket
+            s3_endpoint_url (str): the s3 endpoint url
     """
     reads_uri = f"s3://{os.path.join(reads_bucket, reads_key)}"
     results_uri = f"s3://{os.path.join(results_bucket, name)}"
     submission_dict = {"Name": name,
                        "JobQueue": "ec2-p1-0-1-1",
-                       "JobDefinition": "csu-wgsprocessing-0-1-1:2",
+                       "JobDefinition": "salmonella-ec2-0-1-1:2",
                        "Quantity": 1,
                        "CPU": 4,
                        "RAM_MB": 8192,
@@ -167,7 +166,7 @@ def submit_batch_job(reads_bucket, reads_key, results_bucket, name,
                        "ENV": [],
                        "PARAM": {}}
     utils.upload_json(submission_bucket, f"{name}.scebatch", s3_endpoint_url,
-                      submission_dict)
+                      submission_dict, profile="batch")
 
 
 class BclEventHandler(FileSystemEventHandler):
@@ -306,7 +305,8 @@ class BclEventHandler(FileSystemEventHandler):
             if project_code in SALMONELLA_PROJECT_CODES:
                 submit_batch_job(self.fastq_bucket, key,
                                  self.salm_results_bucket, run_id,
-                                 self.salm_submission_bucket)
+                                 self.salm_submission_bucket,
+                                 self.s3_endpoint_url)
 
     def on_created(self, event):
         """Called when a file or directory is created.
@@ -426,7 +426,7 @@ if __name__ == "__main__":
                         default='https://bucket.vpce-0a9b8c4b880602f6e-w4s7h1by.s3.eu-west-1.vpce.amazonaws.com',
                         help='aws s3 endpoint url for fastq file uploads')
     parser.add_argument('--salmonella-submission-bucket',
-                        default='s3-batch-gbgc-csu-wgsprocessing-0-1-1',
+                        default='s3-batch-cty3-salmonella-ec2-0-1-1',
                         help='S3 bucket for AWS batch submission forms')
     parser.add_argument('--salmonella-results-bucket',
                         default='s3-foo',

--- a/s3_logging_handler.py
+++ b/s3_logging_handler.py
@@ -1,7 +1,7 @@
 from logging import StreamHandler, Handler, FileHandler
 from pathlib import Path
 
-import boto3  
+import boto3
 
 class S3LoggingHandler(FileHandler):
 
@@ -22,7 +22,6 @@ class S3LoggingHandler(FileHandler):
             self.s3 = boto3.client("s3")
         else:
             self.s3 = boto3.client("s3", endpoint_url=endpoint_url)
-            
 
     def emit(self, record):
         """
@@ -33,4 +32,3 @@ class S3LoggingHandler(FileHandler):
 
         # Upload to S3
         self.s3.upload_file(self.baseFilename, self.bucket, self.key)
-

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -28,7 +28,7 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
 
     def test_handler_construction(self):
         # Succeeds when output directories exist
-        bcl_manager.BclEventHandler('./', './', './', '', '', '')
+        bcl_manager.BclEventHandler('./', './', './', '', '', '', '', '')
 
         # Raises exceptions when output directories do not exist
         with self.assertRaises(Exception):
@@ -50,7 +50,8 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
         bcl_manager.shutil.disk_usage.return_value = (0, 0, 0)
 
         # Test handler
-        handler = bcl_manager.BclEventHandler('./', './', './', '', '', '')
+        handler = bcl_manager.BclEventHandler('./', './', './', '', '', '', '',
+                                              '')
 
         # Mocking process_bcl_plate allows us to test on_create without actually doing any processing
         handler.process_bcl_plate = Mock()
@@ -109,20 +110,26 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
         bcl_manager.input = Mock()
 
         # This case should pass
-        bcl_manager.start('./watch_dir/', './fastq_dir/', './backup_dir/', '', '', '')
+        bcl_manager.start('./watch_dir/', './fastq_dir/', './backup_dir/', '',
+                          '', '', '', '')
 
         # These cases would cause catastrophic recursion and should throw pre-emptive exceptions
         with self.assertRaises(SubdirectoryException):
-            bcl_manager.start('./', './', './', '', '', '')
+            bcl_manager.start('./', './', './', '', '', '', '', '')
 
         with self.assertRaises(SubdirectoryException):
-            bcl_manager.start('./', './another/subdirectory/', './', '', '', '')
+            bcl_manager.start('./', './another/subdirectory/', './', '', '',
+                              '', '', '')
 
         with self.assertRaises(SubdirectoryException):
-            bcl_manager.start('./', '/absolute/path/', './another/subdirectory/that/doesnt/exist/', '', '', '')
+            bcl_manager.start('./', '/absolute/path/',
+                              './another/subdirectory/that/doesnt/exist/', '',
+                              '', '', '', '')
 
         with self.assertRaises(SubdirectoryException):
-            bcl_manager.start('./', '/absolute/path/', './subdirectory/doesnt/exist/', '', '', '')
+            bcl_manager.start('./', '/absolute/path/',
+                              './subdirectory/doesnt/exist/', '', '', '', '',
+                              '')
 
     def test_convert_to_fastq(self):
         # Mock subprocess
@@ -156,7 +163,8 @@ class TestBclManager(fake_filesystem_unittest.TestCase):
         bcl_manager.shutil.disk_usage.return_value = (0, 0, 0)
 
         # Test handler
-        handler = bcl_manager.BclEventHandler("./", "./", "./", "", "", "")
+        handler = bcl_manager.BclEventHandler("./", "./", "./", "", "", "", "",
+                                              "")
 
         # Successful upload
         handler.upload(good_event)

--- a/utils.py
+++ b/utils.py
@@ -4,12 +4,13 @@ import subprocess
 import boto3
 import botocore
 
+
 def s3_object_exists(bucket, key, endpoint_url):
     """
         Returns true if the S3 key is in the S3 bucket. False otherwise
         Thanks: https://stackoverflow.com/questions/33842944/check-if-a-key-exists-in-a-bucket-in-s3-using-boto3
     """
-    
+
     key_exists = True
 
     s3 = boto3.resource('s3', endpoint_url=endpoint_url)
@@ -28,25 +29,27 @@ def s3_object_exists(bucket, key, endpoint_url):
 
     return key_exists
 
+
 def s3_sync(src_dir, bucket, key, s3_endpoint_url):
     """
         Upload src_dir to s3://{bucket}/{key}
     """
     target_uri = f's3://{bucket}/{key}'
 
-    # Don't overwrite 
+    # Don't overwrite
     if s3_object_exists(bucket, key, s3_endpoint_url):
         raise Exception(f'{target_uri} already exists')
 
     # Sync
     return_code = subprocess.run([
-        "aws", "s3", 
+        "aws", "s3",
         "--endpoint-url", s3_endpoint_url,
         "sync", src_dir, target_uri
     ]).returncode
 
     if return_code:
-        raise Exception('aws s3 sync failed: %s'%(return_code))
+        raise Exception('aws s3 sync failed: %s' % (return_code))
+
 
 def upload_json(bucket, key, endpoint_url, dictionary, indent=4):
     """
@@ -54,7 +57,7 @@ def upload_json(bucket, key, endpoint_url, dictionary, indent=4):
 
         bucket: S3 Bucket Name
         key: S3 key the json file is stored under
-        dictionary: json serialisable python dictionary for S3 upload 
+        dictionary: json serialisable python dictionary for S3 upload
         endpoint_url: S3 endpoint url
         indent: Number of indentation spaces in the json
     """
@@ -63,14 +66,14 @@ def upload_json(bucket, key, endpoint_url, dictionary, indent=4):
 
     obj.put(Body=(bytes(json.dumps(dictionary, indent=indent).encode('UTF-8'))))
 
+
 def s3_download_file(bucket, key, dest, endpoint_url):
     """
-        Downloads s3 folder at the key-bucket pair (strings) to dest 
+        Downloads s3 folder at the key-bucket pair (strings) to dest
         path (string)
     """
     if s3_object_exists(bucket, key, endpoint_url):
         s3 = boto3.client('s3')
         s3.download_file(bucket, key, dest)
     else:
-        raise Exception(f'{key} not found in {bucket}') 
-
+        raise Exception(f'{key} not found in {bucket}')

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ import boto3
 import botocore
 
 
-def s3_object_exists(bucket, key, endpoint_url):
+def s3_object_exists(bucket, key, s3_endpoint_url):
     """
         Returns true if the S3 key is in the S3 bucket. False otherwise
         Thanks: https://stackoverflow.com/questions/33842944/check-if-a-key-exists-in-a-bucket-in-s3-using-boto3
@@ -13,7 +13,7 @@ def s3_object_exists(bucket, key, endpoint_url):
 
     key_exists = True
 
-    s3 = boto3.resource('s3', endpoint_url=endpoint_url)
+    s3 = boto3.resource('s3', endpoint_url=s3_endpoint_url)
 
     try:
         s3.Object(bucket, key).load()
@@ -51,7 +51,7 @@ def s3_sync(src_dir, bucket, key, s3_endpoint_url):
         raise Exception('aws s3 sync failed: %s' % (return_code))
 
 
-def upload_json(bucket, key, endpoint_url, dictionary, indent=4):
+def upload_json(bucket, key, s3_endpoint_url, dictionary, indent=4):
     """
         Upload json data to s3
 
@@ -61,18 +61,18 @@ def upload_json(bucket, key, endpoint_url, dictionary, indent=4):
         endpoint_url: S3 endpoint url
         indent: Number of indentation spaces in the json
     """
-    s3 = boto3.resource('s3', endpoint_url=endpoint_url)
+    s3 = boto3.resource('s3', endpoint_url=s3_endpoint_url)
     obj = s3.Object(bucket, key)
 
     obj.put(Body=(bytes(json.dumps(dictionary, indent=indent).encode('UTF-8'))))
 
 
-def s3_download_file(bucket, key, dest, endpoint_url):
+def s3_download_file(bucket, key, dest, s3_endpoint_url):
     """
         Downloads s3 folder at the key-bucket pair (strings) to dest
         path (string)
     """
-    if s3_object_exists(bucket, key, endpoint_url):
+    if s3_object_exists(bucket, key, s3_endpoint_url):
         s3 = boto3.client('s3')
         s3.download_file(bucket, key, dest)
     else:

--- a/utils.py
+++ b/utils.py
@@ -51,7 +51,8 @@ def s3_sync(src_dir, bucket, key, s3_endpoint_url):
         raise Exception('aws s3 sync failed: %s' % (return_code))
 
 
-def upload_json(bucket, key, s3_endpoint_url, dictionary, indent=4):
+def upload_json(bucket, key, s3_endpoint_url, dictionary,
+                profile='default', indent=4):
     """
         Upload json data to s3
 
@@ -61,10 +62,14 @@ def upload_json(bucket, key, s3_endpoint_url, dictionary, indent=4):
         endpoint_url: S3 endpoint url
         indent: Number of indentation spaces in the json
     """
-    s3 = boto3.resource('s3', endpoint_url=s3_endpoint_url)
+    # set the aws profile
+    boto3.setup_default_session(profile_name=profile)
+    s3 = boto3.resource('s3', endpoint_url=s3_endpoint_url, profile=profile)
     obj = s3.Object(bucket, key)
 
     obj.put(Body=(bytes(json.dumps(dictionary, indent=indent).encode('UTF-8'))))
+    # reset the aws profile
+    boto3.setup_default_session(profile_name='default')
 
 
 def s3_download_file(bucket, key, dest, s3_endpoint_url):

--- a/utils.py
+++ b/utils.py
@@ -64,7 +64,7 @@ def upload_json(bucket, key, s3_endpoint_url, dictionary,
     """
     # set the aws profile
     boto3.setup_default_session(profile_name=profile)
-    s3 = boto3.resource('s3', endpoint_url=s3_endpoint_url, profile=profile)
+    s3 = boto3.resource('s3', endpoint_url=s3_endpoint_url)
     obj = s3.Object(bucket, key)
 
     obj.put(Body=(bytes(json.dumps(dictionary, indent=indent).encode('UTF-8'))))

--- a/utils.py
+++ b/utils.py
@@ -67,7 +67,8 @@ def upload_json(bucket, key, s3_endpoint_url, dictionary,
     s3 = boto3.resource('s3', endpoint_url=s3_endpoint_url)
     obj = s3.Object(bucket, key)
 
-    obj.put(Body=(bytes(json.dumps(dictionary, indent=indent).encode('UTF-8'))))
+    obj.put(Body=(bytes(json.dumps(dictionary, indent=indent).encode('UTF-8'))),
+            ACL="bucket-owner-full-control")
     # reset the aws profile
     boto3.setup_default_session(profile_name='default')
 


### PR DESCRIPTION
This PR implements submitting Salmonella pipeline test jobs to SCE batch.

ATM the jobs are simply "echoing" the  s3 URI of the salmonella fastq reads from within the Salmonella pipeline docker container in aws batch, I intend to have this running without issues for a week or so before moving onto actually running the pipeline.

### changes
1. A new function `submit_batch_job()` builds the submission form as a python disctionary and then calls `utils.upload_json()` to  upload this dict to the submittions bucket.
2.  `submit_batch_job()` is called from within the excisting `upload()` method and is called when the project code matches `FZ2000`.
3. Additional command line arguments are required `salmonella-submission-bucket` and `salmonella-results-bucket`.
4. Some minor changes to `utils.upload_json()` are required including adding the `ACL` arg to the `boto3.put()` method required for uploading to the submission bucket also the profile for the aws session needs to be set to `batch` to use access keys for the batch submission bucket and then reset to `default` afterwards.
5. Some updates to the unit tests.

I will need to add the access keys to `~/.aws/credentials` under the `batch` profile in `illuminashare` user.


