### PR TITLE
update log output with batch stuff

### DIFF
--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -150,6 +150,7 @@ def submit_batch_job(reads_bucket, reads_key, results_bucket, name,
     """
     reads_uri = f"s3://{os.path.join(reads_bucket, reads_key)}"
     results_uri = f"s3://{os.path.join(results_bucket, name)}"
+    logging.info(f"Submitting reads at {reads_uri} to AWS batch")
     submission_dict = {"Name": name,
                        "JobQueue": "ec2-p1-0-1-1",
                        "JobDefinition": "salmonella-ec2-0-1-1:2",
@@ -273,15 +274,15 @@ class BclEventHandler(FileSystemEventHandler):
         match = re.search(r'(.+)_((.+)_(.+))_(.+)',
                           basename(os.path.dirname(event.fastq_path)))
         if not match:
-            raise Exception(f'Could not extract run number from \
-                            {event.fastq_path}')
+            raise Exception("Could not extract run number from "
+                            f"{event.fastq_path}")
         sequence_date = datetime.strptime(match.group(1), r'%y%m%d')
         run_id = match.group(2)
         instrument_id = match.group(3)
         run_number = match.group(4)
         flowcell_id = match.group(5)
-        logging.info(f'Uploading {event.fastq_path} to \
-                       s3://{self.fastq_bucket}/{self.fastq_key}')
+        logging.info(f"Uploading {event.fastq_path} to "
+                     f"s3://{self.fastq_bucket}/{self.fastq_key}")
         # Upload each directory that contains fastq files
         for dirname in glob.glob(event.fastq_path + '*/'):
             # Skip if no fastq.gz in the directory

--- a/s3_logging_handler.py
+++ b/s3_logging_handler.py
@@ -1,5 +1,4 @@
-from logging import StreamHandler, Handler, FileHandler
-from pathlib import Path
+from logging import FileHandler
 
 import boto3
 

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,21 @@
 import json
 import subprocess
+import contextlib
+from os import devnull
 
 import boto3
 import botocore
+
+
+@contextlib.contextmanager
+def silencer():
+    """
+        A context manager that redirects stdout and stderr to devnull
+    """
+    with open(devnull, "w") as fnull:
+        with contextlib.redirect_stderr(fnull) as err, \
+                contextlib.redirect_stdout(fnull) as out:
+            yield (err, out)
 
 
 def s3_object_exists(bucket, key, s3_endpoint_url):
@@ -63,14 +76,16 @@ def upload_json(bucket, key, s3_endpoint_url, dictionary,
         indent: Number of indentation spaces in the json
     """
     # set the aws profile
-    boto3.setup_default_session(profile_name=profile)
+    with silencer():
+        boto3.setup_default_session(profile_name=profile)
     s3 = boto3.resource('s3', endpoint_url=s3_endpoint_url)
     obj = s3.Object(bucket, key)
 
     obj.put(Body=(bytes(json.dumps(dictionary, indent=indent).encode('UTF-8'))),
             ACL="bucket-owner-full-control")
     # reset the aws profile
-    boto3.setup_default_session(profile_name='default')
+    with silencer():
+        boto3.setup_default_session(profile_name='default')
 
 
 def s3_download_file(bucket, key, dest, s3_endpoint_url):


### PR DESCRIPTION
The main purpose of this PR is to an additional line to log file output which details that a batch job is submitted. This line will say:

`Submitting reads at _x_ to AWS batch`, where _x_ is the s3 URI of the reads. (line 153, `bcl_manager.py`)

I have a also added some code to supress the otuput of the `boto3` code that changes the aws profile. (see `utils`).

```
2023-07-02 04:09:42 - Uploading /Illumina/OutputFastq/FastqRuns/230630_NB501786_0535_AHWM7YBGXT/ to                        s3://s3-csu-001/
2023-07-02 04:09:43 - Found credentials in shared credentials file: ~/.aws/credentials
2023-07-02 04:09:44 - Found credentials in shared credentials file: ~/.aws/credentials
2023-07-02 04:49:26 - Found credentials in shared credentials file: ~/.aws/credentials
2023-07-02 04:49:27 - Found credentials in shared credentials file: ~/.aws/credentials
2023-07-02 05:20:48 - Found credentials in shared credentials file: ~/.aws/credentials
2023-07-02 05:20:52 - Removing old data: '/Illumina/IncomingRuns/230630_NB501786_0535_AHWM7YBGXT'
```