### PR TITLE
log only errors from botocore.credentials

### DIFF
--- a/s3_logging_handler.py
+++ b/s3_logging_handler.py
@@ -1,8 +1,8 @@
-from logging import FileHandler
+import logging
 
 import boto3
 
-class S3LoggingHandler(FileHandler):
+class S3LoggingHandler(logging.FileHandler):
 
     def __init__(self, filename, bucket, key, endpoint_url=None):
         """
@@ -14,6 +14,12 @@ class S3LoggingHandler(FileHandler):
         # S3 Target
         self.bucket = bucket
         self.key = key
+
+        # bit of a hack as botocore.credentials seems log changing
+        # credentials, which is not useful. This forces it to only log
+        # error messages 
+        boto3.set_stream_logger(name='botocore.credentials',
+                                level=logging.ERROR)
 
         # Endpoint Url is required to transfer from Weybridge to the SCE
         # However it is not required for transfers within the SCE

--- a/utils.py
+++ b/utils.py
@@ -7,17 +7,6 @@ import boto3
 import botocore
 
 
-@contextlib.contextmanager
-def silencer():
-    """
-        A context manager that redirects stdout and stderr to devnull
-    """
-    with open(devnull, "w") as fnull:
-        with contextlib.redirect_stderr(fnull) as err, \
-                contextlib.redirect_stdout(fnull) as out:
-            yield (err, out)
-
-
 def s3_object_exists(bucket, key, s3_endpoint_url):
     """
         Returns true if the S3 key is in the S3 bucket. False otherwise
@@ -76,16 +65,14 @@ def upload_json(bucket, key, s3_endpoint_url, dictionary,
         indent: Number of indentation spaces in the json
     """
     # set the aws profile
-    with silencer():
-        boto3.setup_default_session(profile_name=profile)
+    boto3.setup_default_session(profile_name=profile)
     s3 = boto3.resource('s3', endpoint_url=s3_endpoint_url)
     obj = s3.Object(bucket, key)
 
     obj.put(Body=(bytes(json.dumps(dictionary, indent=indent).encode('UTF-8'))),
             ACL="bucket-owner-full-control")
     # reset the aws profile
-    with silencer():
-        boto3.setup_default_session(profile_name='default')
+    boto3.setup_default_session(profile_name='default')
 
 
 def s3_download_file(bucket, key, dest, s3_endpoint_url):


### PR DESCRIPTION
Previous PR didn't actually suppress the aws credentials logging as expected. I believe this should fix the issue.

Basically forcing boto to only log errors associated with `botocore.credentials`.

Further details:

https://github.com/boto/botocore/issues/1841