### PR TITLE
Test salmonella in batch

### DIFF
--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -151,7 +151,7 @@ def submit_batch_job_test(reads_bucket, reads_key, results_bucket, name,
     """
     reads_uri = f"s3://{os.path.join(reads_bucket, reads_key)}"
     results_uri = f"s3://{os.path.join(results_bucket, name)}"
-    logging.info(f"Submitting reads at {reads_uri} to AWS batch")
+    logging.info(f"Submitting to AWS batch: {reads_uri}")
     submission_dict = {"Name": name,
                        "JobQueue": "ec2-p1-0-1-1",
                        "JobDefinition": "salmonella-ec2-0-1-1:2",

--- a/bcl_manager.py
+++ b/bcl_manager.py
@@ -189,7 +189,7 @@ def submit_batch_job(reads_bucket, reads_key, results_bucket, name,
             s3_endpoint_url (str): the s3 endpoint url
     """
     reads_uri = f"s3://{os.path.join(reads_bucket, reads_key)}"
-    results_uri = f"s3://{os.path.join(results_bucket, name)}_{datetime.today().strftime('%Y%m%d%H%M%S')}"
+    results_uri = f"s3://{os.path.join(results_bucket, name)}"
     logging.info(f"Submitting reads at {reads_uri} to AWS batch")
     submission_dict = {"Name": name,
                        "JobQueue": "ec2-p1-0-1-1",
@@ -351,7 +351,8 @@ class BclEventHandler(FileSystemEventHandler):
             # TODO: in future PR, ensure it's within the if statement
             # above (line 342)
             submit_batch_job(self.fastq_bucket, "FZ2000/M01765_0638/",
-                             self.salm_results_bucket, "M01765_0638",
+                             self.salm_results_bucket,
+                             f"M01765_0638_{datetime.today().strftime('%Y%m%d%H%M%S')}",
                              self.salm_submission_bucket,
                              self.s3_endpoint_url)
 


### PR DESCRIPTION
This PR adds a new batch test which will actually run the salmonella pipeline in AWS batch. 

For now, this is hard coded to an historic, small 5GB plate, `FZ2000/M01765_0638/`, and it will run each time a new plate is available regardless of whether this plate contains any salmonella isolates or not.  

I have retained the simple AWS batch job which "echos" the plate name when new data is uploaded with salmonella isolates because for now we are still testing that the code is able to always pick up when salmonella isolates are available.